### PR TITLE
Check for discovered bugs

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -41,6 +41,9 @@ func decrypt(ciphertext []byte, key []byte) (plaintext []byte, err error) {
 	}
 
 	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, io.ErrUnexpectedEOF
+	}
 	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
 
 	plaintext, err = gcm.Open(nil, nonce, ciphertext, nil)

--- a/aes_test.go
+++ b/aes_test.go
@@ -1,0 +1,14 @@
+package lake
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestDecryptShortCiphertext(t *testing.T) {
+	_, err := decrypt([]byte{1, 2, 3}, []byte("key"))
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected io.ErrUnexpectedEOF, got %v", err)
+	}
+}

--- a/func.go
+++ b/func.go
@@ -12,11 +12,12 @@ func getNumericPart(filename string, index int) int64 {
 
 func getSliceNumericPart(parts []string, index int) int64 {
 	// parts := strings.Split(strings.ReplaceAll(filename, ".", "_"), "_")
-	if len(parts) > 0 {
-		num, err := strconv.Atoi(parts[index])
-		if err == nil {
-			return int64(num)
-		}
+	if index < 0 || index >= len(parts) {
+		return 0
+	}
+	num, err := strconv.Atoi(parts[index])
+	if err == nil {
+		return int64(num)
 	}
 	return 0 // 如果解析失败，返回0（或者可以选择处理错误）
 }

--- a/func_test.go
+++ b/func_test.go
@@ -1,0 +1,9 @@
+package lake
+
+import "testing"
+
+func TestGetSliceNumericPartOutOfRange(t *testing.T) {
+	if got := getSliceNumericPart([]string{"1", "2"}, 5); got != 0 {
+		t.Fatalf("expected 0 for out-of-range index, got %d", got)
+	}
+}

--- a/lake.interface.go
+++ b/lake.interface.go
@@ -41,6 +41,7 @@ func (m *lakeEngine) readCryptOSS(obj any, fullPath string) error {
 	if err != nil {
 		return err
 	}
+	defer buffer.Close()
 	data, err := io.ReadAll(buffer)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix critical bugs in AES decryption, slice numeric part extraction, and OSS object stream handling.

This PR addresses three identified bugs:
1.  **`decrypt` panic on short ciphertext:** Previously, `decrypt` would panic if the ciphertext was shorter than the nonce size. It now returns `io.ErrUnexpectedEOF`.
2.  **`getSliceNumericPart` out-of-bounds access:** The function now includes bounds checking for the index, preventing panics when `index` is out of range for the `parts` slice.
3.  **`readCryptOSS` resource leak:** The OSS object stream (`io.ReadCloser`) is now properly closed using `defer buffer.Close()`, preventing connection/file descriptor leaks.
Unit tests have been added for the new boundary conditions.

---
<a href="https://cursor.com/background-agent?bcId=bc-52ce0b78-a900-4bfa-9c85-6ccfad437e1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-52ce0b78-a900-4bfa-9c85-6ccfad437e1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds length/bounds checks to prevent panics in AES decrypt and slice parsing, ensures OSS object stream is closed, and adds tests for these edge cases.
> 
> - **Crypto**:
>   - `decrypt`: Validate ciphertext length against `gcm.NonceSize()`; return `io.ErrUnexpectedEOF` on short input.
> - **Utils**:
>   - `getSliceNumericPart`: Add index bounds check; return `0` when out-of-range or non-numeric.
> - **I/O**:
>   - `readCryptOSS`: Defer `buffer.Close()` after `GetObject` to avoid leaks.
> - **Tests**:
>   - Add `TestDecryptShortCiphertext` and `TestGetSliceNumericPartOutOfRange` to cover new boundary conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb1f660da4a80e9bb52c090fdedbebfd2a0b1c8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->