### PR TITLE
Refactor Sample API: introduce reusable Sampler[T] with layered staleness

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 - **⚡ High Throughput** — Up to 999,999 writes/sec per catalog (Lua-bound seqid)
 - **💾 Smart Caching** — Redis snapshot cache + in-memory delta cache
 - **🎯 Snapshot Acceleration** — Time-range packed snapshots, async generation
-- **🧮 Generic Sampling** — `Sample[T]` computes derived data on demand and
-  caches it atomically; replaces v2's separate "meta" concept
+- **🧮 Generic Sampling** — `NewSampler[T]` computes derived data on demand
+  with a layered staleness policy; replaces v2's separate "meta" concept
 - **🔍 Event Middleware** — `client.Use(handler)` for logging / monitoring
 - **🔐 Optional AES-GCM Encryption** — minimal overhead, configurable via
   `lake.setting`
@@ -222,33 +222,64 @@ profile, err := lake.Read[UserProfile](ctx, list)
 
 ### Sample (computed, cached)
 
-`Sample[T]` is the canonical way to derive secondary state from a catalog.
-The first call invokes `loader`, and subsequent calls reuse the cached value
-unless the catalog has changed (compared by `LastUpdated()`).
+`NewSampler[T]` is the single entry point for deriving secondary state from a
+catalog. Construct one `Sampler` per `(indicator, T, loader)` and reuse it: it
+memoises each catalog's computed value in Redis and recomputes only when the
+value is stale.
 
-| Function | File | Description |
-|----------|------|-------------|
-| `Sample[T](ctx, *ListResult, indicator, loader) (T, error)` | [sample.go](sample.go) | Generic cached sampling |
-| `ErrPendingWrites` | [sample.go](sample.go) | Returned when the list reports pending writes |
+| API | File | Description |
+|-----|------|-------------|
+| `NewSampler[T](indicator, loader, …opts) *Sampler[T]` | [sample.go](sample.go) | Build a reusable sampler |
+| `(*Sampler[T]) Sample(ctx, *ListResult) (T, error)` | [sample.go](sample.go) | One catalog: hit → 1 HGET, miss → loader + HSET |
+| `(*Sampler[T]) Batch(ctx, map[string]*ListResult) map[string]*SampleResult[T]` | [sample.go](sample.go) | Many catalogs: 1 HMGET + concurrent loaders for misses |
 
 ```go
-list := client.List(ctx, "users")
-report, err := lake.Sample[Report](ctx, list, "daily",
+sampler := lake.NewSampler[Report]("daily",
     func(l *lake.ListResult) (Report, error) {
         data, err := lake.ReadMap(ctx, l)
         if err != nil {
             return Report{}, err
         }
         return buildReport(data), nil
-    })
-// data unchanged → 1× HGET, returns cached Report
-// data changed   → loader runs, result is HSET'd atomically with the score
+    },
+    lake.WithMaxAge(time.Hour),                              // recompute hourly even if data is unchanged
+    lake.WithLoaderErrorDefault(Report{Status: "degraded"}), // serve a default if the loader fails (never cached)
+)
+
+list := client.List(ctx, "users")
+report, err := sampler.Sample(ctx, list)
 ```
 
-**Storage layout**: Sample results live in
-`{prefix}:samples:{indicator}` Redis Hashes, with each catalog as a field
-holding a `[score, data]` JSON array. All catalogs sharing one indicator are
-colocated, so indicator-wide enumeration / clearing is single-key.
+**Staleness is layered.** A cached sample is reused only while fresh:
+
+1. **Data-version floor (always on)** — if the catalog advanced past the
+   version the sample was computed at (`ListResult.LastUpdated()`), it is
+   recomputed. But the data version alone is not the whole story: the *same*
+   version can still need a refresh, because a derived value can depend on
+   more than the catalog's own bytes.
+2. **`WithMaxAge(d)`** — recompute when the entry is older than `d` by the
+   Redis server clock. For time-sensitive derivations (a "today" report is
+   correct only for today, not forever).
+3. **`WithShouldRefresh(fn)`** — a custom predicate, the analog of React's
+   `shouldComponentUpdate`: return `true` to force a recompute even when the
+   data version is unchanged (cross-catalog dependencies, external inputs).
+   It runs on every cache hit, so it must be pure and cheap — no I/O; compare
+   versions you already hold (e.g. from the same `BatchList`).
+
+These triggers can only *add* recomputes; none serves a value older than the
+data-version floor allows.
+
+**Errors never poison the cache.** A loader error — or its
+`WithLoaderErrorDefault` / `WithLoaderErrorFallback` substitute — is a
+per-call response and is never written back, so a transient blip (a database
+hiccup) cannot freeze a degraded value into the cache until the next write.
+Cache-tier failures degrade gracefully too: a failed read recomputes, a
+failed write still returns the freshly computed value.
+
+**Storage layout**: samples live in `{prefix}:samples:{indicator}` Redis
+Hashes, each catalog a field holding a `[score, updatedAt, data]` JSON array
+(`score` = data version, `updatedAt` = compute time). All catalogs sharing one
+indicator are colocated, so indicator-wide enumeration / clearing is single-key.
 
 ### Cleanup
 
@@ -307,7 +338,7 @@ lake/
 ├── helpers.go           # ReadBytes, ReadString, ReadMap, Read[T]
 ├── clear.go             # ClearHistory entry points
 ├── clear_optimized.go   # Concurrent storage delete + batch ZREM
-├── sample.go            # Sample[T], ErrPendingWrites
+├── sample.go            # Sampler[T] (NewSampler): cached derived sampling
 ├── snapshot.go          # Async snapshot save under SingleFlight
 ├── export.go            # MergeType re-exports
 └── internal/
@@ -472,7 +503,8 @@ back later. Callers must therefore avoid `:` and `|` in catalog names today.
 
 {prefix}:samples:{indicator}   Hash
   field = catalog
-  value = [score, data]                         # JSON array, atomic per HSET
+  value = [score, updatedAt, data]              # JSON array, atomic per HSET
+                                                # score=data version, updatedAt=compute time
 ```
 
 ### Object storage
@@ -568,12 +600,14 @@ v3 is **not** wire-compatible with v2 callers. Concretely:
 
 - **Module path**: `github.com/hkloudou/lake/v2` → `github.com/hkloudou/lake/v3`
 - **`WriteRequest.Meta` removed.** v2's catalog-level meta is gone — derived
-  state now goes through `Sample[T]` instead. Callers that stored meta-as-JSON
-  alongside writes should compute it lazily inside a `Sample[T]` loader.
+  state now goes through `NewSampler[T]` instead. Callers that stored
+  meta-as-JSON alongside writes should compute it lazily inside a sampler's loader.
 - **File API removed.** `WriteFile`, `FileExists`, `FilesAndMeta`,
   `WriteFileRequest`, and `Storage.MakeFileKey` are gone. Lake v3 handles
   JSON documents only.
-- **`MotionSample` (v1 sample) removed.** Use generic `Sample[T]` instead.
+- **`MotionSample` (v1 sample) removed.** Use `NewSampler[T]` instead — its
+  `WithShouldRefresh` predicate and `Batch` over many catalogs subsume v1's
+  `shouldUpdated` callback and `motionCatalogs` cross-catalog sampling.
 - **Sample storage layout inverted.** v2 used
   `{prefix}:{catalog}:sample` Hashes with the indicator as the field. v3 uses
   `{prefix}:samples:{indicator}` Hashes with the catalog as the field. v2
@@ -591,8 +625,6 @@ v3 is **not** wire-compatible with v2 callers. Concretely:
 - **`merge.Merge` signature** changed: dropped the unused `catalog` parameter
   and the always-empty second return value. (Internal API.)
 - **`Writer.Commit` signature** dropped the meta argument. (Internal API.)
-- **Named error**: pending writes now surface as `lake.ErrPendingWrites`,
-  compatible with `errors.Is`.
 
 If you depend on any of the removed surfaces and cannot rewrite, **stay on
 the v2 line**: it remains maintained on the [`v2` branch](https://github.com/hkloudou/lake/tree/v2)

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -206,6 +206,16 @@ func (r *Reader) timeUpdater() {
 	}
 }
 
+// NowUnix returns Lake's notion of the current time in unix seconds,
+// taken from the Redis server clock (refreshed every 5s). During the
+// brief window before the first sync it falls back to the local clock.
+func (r *Reader) NowUnix() int64 {
+	if t := r.redisTimeUnix.Load(); t > 0 {
+		return t
+	}
+	return time.Now().Unix()
+}
+
 func (r *Reader) serverUnix(ctx context.Context) (int64, error) {
 	res, err := r.rdb.Eval(ctx, `return tonumber(redis.call("TIME")[1])`, nil).Result()
 	if err != nil {

--- a/lake.go
+++ b/lake.go
@@ -34,7 +34,7 @@ type Client struct {
 	config  *config.Config
 
 	snapFlight   xsync.SingleFlight[string]   // dedupe concurrent snapshot saves on (catalog, stop)
-	sampleFlight xsync.SingleFlight[string]   // dedupe concurrent Sample[T] loaders on (catalog, indicator, score)
+	sampleFlight xsync.SingleFlight[string]   // dedupe concurrent Sampler[T] loaders on (catalog, indicator, score)
 	clearFlight  xsync.SingleFlight[struct{}] // dedupe concurrent ClearHistory on (catalog)
 
 	eventHandlers []EventHandler

--- a/middleware_event_test.go
+++ b/middleware_event_test.go
@@ -96,10 +96,9 @@ func TestEmit_SampleFiresOnListErr(t *testing.T) {
 	// Hand-craft a ListResult with Err so Sample short-circuits;
 	// emit must still fire.
 	list := &ListResult{client: c, catalog: "users", Err: errIntentional}
-	_, err := Sample[map[string]any](
-		context.Background(), list, "report",
-		func(*ListResult) (map[string]any, error) { return nil, nil },
-	)
+	sampler := NewSampler[map[string]any]("report",
+		func(*ListResult) (map[string]any, error) { return nil, nil })
+	_, err := sampler.Sample(context.Background(), list)
 	if err == nil {
 		t.Fatal("expected list-err propagation, got nil")
 	}

--- a/sample.go
+++ b/sample.go
@@ -6,24 +6,124 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
 
-// Sample returns the cached sample of type T for the given indicator
-// applied to list's catalog. If the catalog changed since the last
-// sample (compared by ListResult.LastUpdated), loader is invoked and
-// the new value is cached for future calls.
+// Sampler[T] is the single entry point for derived, cached sampling.
 //
-// Storage layout: all catalogs sharing one indicator live inside
-// "<prefix>:samples:<indicator>" Hash, with catalog as field and
-// "[score, data]" JSON as value. Indicator-wide bulk operations stay
-// single-key.
-func Sample[T any](ctx context.Context, list *ListResult, indicator string, loader func(*ListResult) (T, error)) (T, error) {
-	var zero T
+// A "sample" is a value of type T computed from a catalog's raw state
+// (snap + deltas) by a loader, then memoised in the
+// "<prefix>:samples:<indicator>" Redis Hash (catalog = field). Construct
+// one Sampler per (indicator, T, loader) and reuse it: the staleness
+// policy and error fallback are bound at construction so every call site
+// stays uniform.
+//
+// Validity is layered. The data-version floor is mandatory — if the
+// catalog advanced past the version the sample was computed at, it is
+// recomputed. WithMaxAge and WithShouldRefresh add further triggers (the
+// analog of React's shouldComponentUpdate: force a "re-render" even when
+// the data version is unchanged); they can only cause MORE recomputes,
+// never serve a value staler than the floor allows.
+//
+// The cache only ever holds genuinely computed values. A loader error,
+// and any fallback substituted for it, is returned to the caller but
+// never written back — so a transient failure cannot poison the cache
+// until the catalog's next write.
+type Sampler[T any] struct {
+	indicator     string
+	loader        func(*ListResult) (T, error)
+	maxAge        time.Duration
+	shouldRefresh func(SampleMeta, *ListResult) bool
+	onLoaderErr   func(error) (T, bool)
+}
 
+// SampleMeta is the metadata stored alongside each cached sample, and the
+// input a WithShouldRefresh predicate compares against.
+type SampleMeta struct {
+	// Score is the catalog's data version (ListResult.LastUpdated) at the
+	// moment the sample was computed.
+	Score float64
+	// UpdatedAt is the Redis-server wall clock (unix seconds) when the
+	// sample was computed; the basis for WithMaxAge.
+	UpdatedAt int64
+}
+
+// SampleResult is one entry of Batch's output: a value, or an error
+// scoped to that single catalog.
+type SampleResult[T any] struct {
+	Value T
+	Err   error
+}
+
+// SamplerOption configures a Sampler at construction.
+type SamplerOption[T any] func(*Sampler[T])
+
+// NewSampler builds a reusable Sampler for one indicator. loader computes
+// the sample from a catalog's ListResult on a cache miss. It panics if
+// indicator is empty or loader is nil (programmer error — fail-fast, per
+// package policy).
+func NewSampler[T any](indicator string, loader func(*ListResult) (T, error), opts ...SamplerOption[T]) *Sampler[T] {
+	if indicator == "" {
+		panic("lake: NewSampler indicator must be non-empty")
+	}
+	if loader == nil {
+		panic("lake: NewSampler loader must be non-nil")
+	}
+	s := &Sampler[T]{indicator: indicator, loader: loader}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// WithMaxAge forces a recompute when the cached sample is older than d,
+// measured by the Redis server clock (~5s resolution), regardless of data
+// version. Use it for time-sensitive derivations whose correctness depends
+// on wall-clock and not just catalog data (e.g. a "today" report). d <= 0
+// disables the check.
+func WithMaxAge[T any](d time.Duration) SamplerOption[T] {
+	return func(s *Sampler[T]) { s.maxAge = d }
+}
+
+// WithShouldRefresh installs a custom staleness predicate — the analog of
+// React's shouldComponentUpdate. It receives the cached entry's metadata
+// and the current list and returns true to force a recompute even when the
+// data version is unchanged (cross-catalog dependencies, external inputs).
+//
+// It runs on every cache hit, so it MUST be pure and cheap: do no I/O.
+// Cross-catalog dependencies should compare versions already in hand
+// (e.g. fetched by the same BatchList), never fetch them here.
+func WithShouldRefresh[T any](fn func(SampleMeta, *ListResult) bool) SamplerOption[T] {
+	return func(s *Sampler[T]) { s.shouldRefresh = fn }
+}
+
+// WithLoaderErrorFallback substitutes a value when the loader returns an
+// error. fn inspects that error and returns (value, true) to serve the
+// value for this call only, or (_, false) to propagate the error. The
+// substitute is transient — it is NEVER written to the cache, so the next
+// call retries the loader. fn may run concurrently (Batch) and should be
+// safe to call from multiple goroutines.
+func WithLoaderErrorFallback[T any](fn func(error) (T, bool)) SamplerOption[T] {
+	return func(s *Sampler[T]) { s.onLoaderErr = fn }
+}
+
+// WithLoaderErrorDefault is WithLoaderErrorFallback that always serves v on
+// any loader error.
+func WithLoaderErrorDefault[T any](v T) SamplerOption[T] {
+	return func(s *Sampler[T]) { s.onLoaderErr = func(error) (T, bool) { return v, true } }
+}
+
+// Sample returns the sample for list's catalog, computing and caching it
+// on a miss or when the staleness policy fires.
+func (s *Sampler[T]) Sample(ctx context.Context, list *ListResult) (T, error) {
+	var zero T
+	if list == nil || list.client == nil {
+		return zero, errors.New("lake: Sample requires a ListResult from List/BatchList")
+	}
 	c := list.client
-	c.emitEvent(list.catalog, "Sample", map[string]any{"indicator": indicator})
+	c.emitEvent(list.catalog, "Sample", map[string]any{"indicator": s.indicator})
 
 	if list.Err != nil {
 		return zero, list.Err
@@ -31,54 +131,24 @@ func Sample[T any](ctx context.Context, list *ListResult, indicator string, load
 	if err := c.ensureInitialized(ctx); err != nil {
 		return zero, err
 	}
-
-	lastUpdated := list.LastUpdated()
-	hashKey := c.reader.MakeSampleIndicatorKey(indicator)
-
-	// Cache hit fast-path: one HGET; values are "[score, data]" JSON arrays.
-	if cached, err := c.rdb.HGet(ctx, hashKey, list.catalog).Bytes(); err == nil {
-		if score, data, derr := unmarshalSampleCache[T](cached); derr == nil && score >= lastUpdated && score > 0 {
-			return data, nil
-		}
-	} else if err != redis.Nil {
-		return zero, err
-	}
-
-	return loadAndCacheSample(ctx, c, list, indicator, hashKey, lastUpdated, loader)
+	return s.finalize(s.sampleCore(ctx, c, list))
 }
 
-// BatchSampleResult is one entry in BatchSample's output: either a
-// loaded/cached value or an error scoped to that catalog.
-type BatchSampleResult[T any] struct {
-	Value T
-	Err   error
-}
-
-// BatchSample fetches the same indicator for many catalogs in one
-// HMGet of "<prefix>:samples:<indicator>". Cache hits return immediately;
-// misses run loader concurrently (10 workers) and write back via HSet
-// inside the same per-(catalog, indicator, score) SingleFlight that
-// Sample uses, so concurrent Sample + BatchSample calls dedupe.
-//
-// Errors are isolated per catalog: a list with Err / HasPending / a
-// failing loader only poisons its own BatchSampleResult.
-//
-// Designed to be piped from BatchList:
+// Batch fetches the same indicator for many catalogs in one HMGet, running
+// the loader concurrently (10 workers) only for misses; cache hits return
+// immediately. Errors are isolated per catalog. Misses dedupe against the
+// same SingleFlight as Sample, so concurrent Sample + Batch calls share a
+// loader run. Designed to be piped from BatchList:
 //
 //	lists := client.BatchList(ctx, catalogs)
-//	results := lake.BatchSample[Report](ctx, lists, "daily", loader)
-func BatchSample[T any](
-	ctx context.Context,
-	lists map[string]*ListResult,
-	indicator string,
-	loader func(*ListResult) (T, error),
-) map[string]*BatchSampleResult[T] {
-	out := make(map[string]*BatchSampleResult[T], len(lists))
+//	results := sampler.Batch(ctx, lists)
+func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) map[string]*SampleResult[T] {
+	out := make(map[string]*SampleResult[T], len(lists))
 	if len(lists) == 0 {
 		return out
 	}
 
-	// Pick any client; ListResults from BatchList all share one.
+	// Any ListResult from BatchList carries the same client.
 	var c *Client
 	for _, l := range lists {
 		if l != nil && l.client != nil {
@@ -87,34 +157,32 @@ func BatchSample[T any](
 		}
 	}
 	if c == nil {
-		err := errors.New("BatchSample: no client (empty or invalid lists)")
+		err := errors.New("lake: Batch has no client (empty or invalid lists)")
 		for cat := range lists {
-			out[cat] = &BatchSampleResult[T]{Err: err}
+			out[cat] = &SampleResult[T]{Err: err}
 		}
 		return out
 	}
 
-	// Emit per catalog before any early return (mirrors BatchList).
 	for cat := range lists {
-		c.emitEvent(cat, "BatchSample", map[string]any{"indicator": indicator})
+		c.emitEvent(cat, "BatchSample", map[string]any{"indicator": s.indicator})
 	}
-
 	if err := c.ensureInitialized(ctx); err != nil {
 		for cat := range lists {
-			out[cat] = &BatchSampleResult[T]{Err: err}
+			out[cat] = &SampleResult[T]{Err: err}
 		}
 		return out
 	}
 
-	// Partition: drop catalogs that already have list-level errors;
-	// remaining go into the HMGet probe.
+	// Partition: drop catalogs that already have list-level errors; the
+	// rest go into the HMGet probe.
 	probe := make([]string, 0, len(lists))
 	for cat, l := range lists {
 		switch {
 		case l == nil:
-			out[cat] = &BatchSampleResult[T]{Err: errors.New("nil list")}
+			out[cat] = &SampleResult[T]{Err: errors.New("nil list")}
 		case l.Err != nil:
-			out[cat] = &BatchSampleResult[T]{Err: l.Err}
+			out[cat] = &SampleResult[T]{Err: l.Err}
 		default:
 			probe = append(probe, cat)
 		}
@@ -123,18 +191,19 @@ func BatchSample[T any](
 		return out
 	}
 
-	hashKey := c.reader.MakeSampleIndicatorKey(indicator)
+	now := c.reader.NowUnix()
+	hashKey := c.reader.MakeSampleIndicatorKey(s.indicator)
 
-	// One HMGet to surface every cache hit at once.
 	cached, err := c.rdb.HMGet(ctx, hashKey, probe...).Result()
 	if err != nil && err != redis.Nil {
+		// Cache-read failure: degrade to recompute-all rather than fail
+		// the batch (the cache is an optimization, not the truth).
 		for _, cat := range probe {
-			out[cat] = &BatchSampleResult[T]{Err: fmt.Errorf("hmget samples: %w", err)}
+			c.emitEvent(cat, "SampleCacheError", map[string]any{"op": "hmget", "err": err.Error()})
 		}
-		return out
+		cached = make([]any, len(probe))
 	}
 
-	// Classify: hit serves immediately, miss queues for the worker pool.
 	var (
 		mu     sync.Mutex
 		misses []string
@@ -142,10 +211,9 @@ func BatchSample[T any](
 	for i, raw := range cached {
 		cat := probe[i]
 		l := lists[cat]
-		lastUpdated := l.LastUpdated()
-		if s, ok := raw.(string); ok {
-			if score, data, derr := unmarshalSampleCache[T]([]byte(s)); derr == nil && score >= lastUpdated && score > 0 {
-				out[cat] = &BatchSampleResult[T]{Value: data}
+		if str, ok := raw.(string); ok {
+			if meta, data, derr := unmarshalSampleCache[T]([]byte(str)); derr == nil && !s.isStale(meta, l, now) {
+				out[cat] = &SampleResult[T]{Value: data}
 				continue
 			}
 		}
@@ -155,7 +223,6 @@ func BatchSample[T any](
 		return out
 	}
 
-	// Worker pool: 10 concurrent loaders, dedupe via sampleFlight.
 	workers := 10
 	if len(misses) < workers {
 		workers = len(misses)
@@ -166,9 +233,9 @@ func BatchSample[T any](
 		wg.Go(func() {
 			for cat := range jobs {
 				l := lists[cat]
-				value, err := loadAndCacheSample(ctx, c, l, indicator, hashKey, l.LastUpdated(), loader)
+				v, e := s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), now))
 				mu.Lock()
-				out[cat] = &BatchSampleResult[T]{Value: value, Err: err}
+				out[cat] = &SampleResult[T]{Value: v, Err: e}
 				mu.Unlock()
 			}
 		})
@@ -178,64 +245,125 @@ func BatchSample[T any](
 	}
 	close(jobs)
 	wg.Wait()
-
 	return out
 }
 
-// loadAndCacheSample is the shared cache-fill path for Sample and
-// BatchSample. Wraps loader in the (catalog, indicator, score)
-// SingleFlight, encodes as "[score, data]", and HSets the result.
-//
-// Generic free function (not a method) because Go forbids generic
-// methods on a non-generic receiver.
-func loadAndCacheSample[T any](
-	ctx context.Context,
-	c *Client,
-	list *ListResult,
-	indicator, hashKey string,
-	lastUpdated float64,
-	loader func(*ListResult) (T, error),
-) (T, error) {
+// isStale decides whether a cached entry must be recomputed. The data-
+// version floor is mandatory; maxAge and shouldRefresh only ADD triggers
+// (they can force a refresh, never suppress one the data version requires).
+func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, now int64) bool {
+	lastUpdated := list.LastUpdated()
+	if !(meta.Score >= lastUpdated && meta.Score > 0) {
+		return true // data advanced past the cached version (or none) → refresh
+	}
+	if s.maxAge > 0 && now > 0 && meta.UpdatedAt > 0 && now-meta.UpdatedAt >= int64(s.maxAge.Seconds()) {
+		return true
+	}
+	if s.shouldRefresh != nil && s.shouldRefresh(meta, list) {
+		return true
+	}
+	return false
+}
+
+// sampleCore is the cache-or-compute path for a single catalog: one HGET,
+// then load on miss/stale. A cache-READ failure degrades to recompute — it
+// never fails the call.
+func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult) (T, error) {
+	lastUpdated := list.LastUpdated()
+	now := c.reader.NowUnix()
+	hashKey := c.reader.MakeSampleIndicatorKey(s.indicator)
+
+	if cached, err := c.rdb.HGet(ctx, hashKey, list.catalog).Bytes(); err == nil {
+		if meta, data, derr := unmarshalSampleCache[T](cached); derr == nil && !s.isStale(meta, list, now) {
+			return data, nil
+		}
+	} else if err != redis.Nil {
+		c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hget", "err": err.Error()})
+	}
+	return s.loadAndCache(ctx, c, list, hashKey, lastUpdated, now)
+}
+
+// loadAndCache runs the loader under the (catalog, indicator, version)
+// SingleFlight, stamps [score, updatedAt, data], and writes it back
+// best-effort. A loader error is wrapped (loaderError) so finalize can
+// distinguish it from an internal encode error; a cache-WRITE failure is
+// swallowed — the computed value is already correct and is returned anyway.
+func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResult, hashKey string, lastUpdated float64, now int64) (T, error) {
 	var zero T
-	flightKey := fmt.Sprintf("%s:%s:%.6f", list.catalog, indicator, lastUpdated)
+	flightKey := fmt.Sprintf("%s:%s:%.6f", list.catalog, s.indicator, lastUpdated)
 	raw, err := c.sampleFlight.Do(flightKey, func() (string, error) {
-		result, err := loader(list)
-		if err != nil {
-			return "", err
+		result, lerr := s.loader(list)
+		if lerr != nil {
+			return "", &loaderError{err: lerr}
 		}
-		data, err := marshalSampleCache(lastUpdated, result)
-		if err != nil {
-			return "", fmt.Errorf("marshal sample: %w", err)
+		data, merr := marshalSampleCache(SampleMeta{Score: lastUpdated, UpdatedAt: now}, result)
+		if merr != nil {
+			return "", fmt.Errorf("marshal sample: %w", merr)
 		}
-		if err := c.rdb.HSet(ctx, hashKey, list.catalog, data).Err(); err != nil {
-			return "", fmt.Errorf("hset sample: %w", err)
+		if werr := c.rdb.HSet(ctx, hashKey, list.catalog, data).Err(); werr != nil {
+			c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hset", "err": werr.Error()})
 		}
 		return string(data), nil
 	})
 	if err != nil {
 		return zero, err
 	}
-	_, value, err := unmarshalSampleCache[T]([]byte(raw))
-	return value, err
+	_, value, derr := unmarshalSampleCache[T]([]byte(raw))
+	return value, derr
 }
 
-func marshalSampleCache[T any](score float64, data T) ([]byte, error) {
-	return json.Marshal([2]any{score, data})
-}
-
-func unmarshalSampleCache[T any](raw []byte) (float64, T, error) {
-	var arr [2]json.RawMessage
+// finalize applies the loader-error fallback. A substituted value is
+// returned to the caller only — never cached. Internal (non-loader) errors
+// and a declined fallback propagate; the caller always sees their original
+// loader error (unwrapped) so errors.Is on their own sentinels still works.
+func (s *Sampler[T]) finalize(v T, err error) (T, error) {
 	var zero T
-	if err := json.Unmarshal(raw, &arr); err != nil {
-		return 0, zero, err
+	if err == nil {
+		return v, nil
 	}
-	var score float64
-	if err := json.Unmarshal(arr[0], &score); err != nil {
-		return 0, zero, err
+	var le *loaderError
+	if errors.As(err, &le) {
+		if s.onLoaderErr != nil {
+			if d, ok := s.onLoaderErr(le.err); ok {
+				return d, nil
+			}
+		}
+		return zero, le.err
+	}
+	return zero, err
+}
+
+// loaderError tags an error as originating from the caller's loader (vs an
+// internal encode failure), so finalize can scope the fallback correctly.
+type loaderError struct{ err error }
+
+func (e *loaderError) Error() string { return e.err.Error() }
+func (e *loaderError) Unwrap() error { return e.err }
+
+// Cache value format: a JSON array "[score, updatedAt, data]". score is the
+// data version and updatedAt the compute wall-clock; data is the sample.
+func marshalSampleCache[T any](meta SampleMeta, data T) ([]byte, error) {
+	return json.Marshal([3]any{meta.Score, meta.UpdatedAt, data})
+}
+
+func unmarshalSampleCache[T any](raw []byte) (SampleMeta, T, error) {
+	var (
+		arr  [3]json.RawMessage
+		meta SampleMeta
+		zero T
+	)
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return meta, zero, err
+	}
+	if err := json.Unmarshal(arr[0], &meta.Score); err != nil {
+		return meta, zero, err
+	}
+	if err := json.Unmarshal(arr[1], &meta.UpdatedAt); err != nil {
+		return meta, zero, err
 	}
 	var data T
-	if err := json.Unmarshal(arr[1], &data); err != nil {
-		return 0, zero, err
+	if err := json.Unmarshal(arr[2], &data); err != nil {
+		return meta, zero, err
 	}
-	return score, data, nil
+	return meta, data, nil
 }

--- a/sample_batch_redis_test.go
+++ b/sample_batch_redis_test.go
@@ -56,7 +56,7 @@ func TestBatchSample_HitsAndMisses_Redis(t *testing.T) {
 	stop := index.TimeSeqID{Timestamp: 1700000100, SeqID: 500}
 
 	// Pre-seed a cache hit for "users" at score == lastUpdated.
-	primed, err := marshalSampleCache(stop.Score(), 7)
+	primed, err := marshalSampleCache(SampleMeta{Score: stop.Score(), UpdatedAt: time.Now().Unix()}, 7)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestBatchSample_HitsAndMisses_Redis(t *testing.T) {
 		t.Errorf("loader unexpectedly invoked for %q", l.catalog)
 		return 0, nil
 	}
-	out := BatchSample[int](ctx, lists, "daily", loader)
+	out := NewSampler[int]("daily", loader).Batch(ctx, lists)
 
 	if got := calls.Load(); got != 2 {
 		t.Errorf("loader call count: got %d, want 2 (one per miss)", got)

--- a/sample_batch_test.go
+++ b/sample_batch_test.go
@@ -11,7 +11,7 @@ import (
 
 // initedClient builds a Client whose ensureInitialized succeeds without
 // reaching Redis (memory storage injected). Tests that don't need a
-// real Redis use this to focus on BatchSample's branching logic.
+// real Redis use this to focus on Sampler.Batch's branching logic.
 func initedClient(t *testing.T) *Client {
 	t.Helper()
 	c := NewLake("127.0.0.1:1", WithStorage(storage.NewMemoryStorage("test")))
@@ -23,15 +23,16 @@ func initedClient(t *testing.T) *Client {
 
 // TestBatchSample_EmptyInput: zero catalogs in → empty map out, no panics.
 func TestBatchSample_EmptyInput(t *testing.T) {
-	out := BatchSample[int](context.Background(), nil, "x", func(*ListResult) (int, error) { return 0, nil })
+	s := NewSampler[int]("x", func(*ListResult) (int, error) { return 0, nil })
+	out := s.Batch(context.Background(), nil)
 	if len(out) != 0 {
 		t.Fatalf("expected empty result, got %v", out)
 	}
 }
 
-// TestBatchSample_PreservesPerCatalogErrors: list-level errors and
-// HasPending must surface on their own catalog only, never invoke
-// loader, and not be overridden by post-init paths.
+// TestBatchSample_PreservesPerCatalogErrors: list-level errors must surface
+// on their own catalog only, never invoke the loader, and not be overridden
+// by post-init paths.
 func TestBatchSample_PreservesPerCatalogErrors(t *testing.T) {
 	c := initedClient(t)
 
@@ -40,10 +41,11 @@ func TestBatchSample_PreservesPerCatalogErrors(t *testing.T) {
 		"with-err": {client: c, catalog: "with-err", Err: listErr},
 	}
 	loaderCalls := atomic.Int32{}
-	out := BatchSample[int](context.Background(), lists, "daily", func(*ListResult) (int, error) {
+	s := NewSampler[int]("daily", func(*ListResult) (int, error) {
 		loaderCalls.Add(1)
 		return 1, nil
 	})
+	out := s.Batch(context.Background(), lists)
 
 	if !errors.Is(out["with-err"].Err, listErr) {
 		t.Errorf("expected list err to surface, got %v", out["with-err"].Err)
@@ -61,7 +63,8 @@ func TestBatchSample_NilListEntry(t *testing.T) {
 		"valid": {client: c, catalog: "valid", Err: errors.New("dummy")},
 		"nil":   nil,
 	}
-	out := BatchSample[int](context.Background(), lists, "x", func(*ListResult) (int, error) { return 0, nil })
+	s := NewSampler[int]("x", func(*ListResult) (int, error) { return 0, nil })
+	out := s.Batch(context.Background(), lists)
 	if out["nil"].Err == nil {
 		t.Fatal("expected error for nil list entry")
 	}
@@ -75,7 +78,8 @@ func TestBatchSample_NoClientFallback(t *testing.T) {
 		"a": {catalog: "a"},
 		"b": {catalog: "b"},
 	}
-	out := BatchSample[int](context.Background(), lists, "x", func(*ListResult) (int, error) { return 0, nil })
+	s := NewSampler[int]("x", func(*ListResult) (int, error) { return 0, nil })
+	out := s.Batch(context.Background(), lists)
 	if len(out) != 2 || out["a"].Err == nil || out["b"].Err == nil {
 		t.Fatalf("expected per-catalog errors when no client is available, got %+v", out)
 	}

--- a/sample_test.go
+++ b/sample_test.go
@@ -1,0 +1,118 @@
+package lake
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hkloudou/lake/v3/internal/index"
+)
+
+// listAt builds a ListResult whose LastUpdated() == score.
+func listAt(score float64) *ListResult {
+	return &ListResult{Entries: []index.DeltaInfo{{Score: score}}}
+}
+
+// TestSampleCacheCodec round-trips the [score, updatedAt, data] format and
+// confirms the legacy 2-element [score, data] format fails to decode (so a
+// reader treats it as a miss and recomputes).
+func TestSampleCacheCodec(t *testing.T) {
+	raw, err := marshalSampleCache(SampleMeta{Score: 12.5, UpdatedAt: 1700}, map[string]int{"a": 1})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	meta, data, err := unmarshalSampleCache[map[string]int](raw)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if meta.Score != 12.5 || meta.UpdatedAt != 1700 {
+		t.Fatalf("meta round-trip: got %+v", meta)
+	}
+	if data["a"] != 1 {
+		t.Fatalf("data round-trip: got %+v", data)
+	}
+
+	// Legacy 2-element format must NOT decode as a valid 3-element entry.
+	if _, _, err := unmarshalSampleCache[map[string]int]([]byte(`[12.5,{"a":1}]`)); err == nil {
+		t.Fatal("legacy 2-element cache value must fail to decode (forces recompute)")
+	}
+}
+
+// TestSamplerIsStale locks in the layered staleness contract: the data-
+// version floor is mandatory, while maxAge and shouldRefresh can only ADD
+// refresh triggers — never suppress one the data version requires.
+func TestSamplerIsStale(t *testing.T) {
+	base := NewSampler[int]("x", func(*ListResult) (int, error) { return 0, nil })
+
+	// Floor satisfied: cached version >= current, positive → fresh.
+	if base.isStale(SampleMeta{Score: 100}, listAt(100), 0) {
+		t.Error("equal version should be fresh")
+	}
+	// Data advanced → stale regardless of anything else.
+	if !base.isStale(SampleMeta{Score: 100}, listAt(200), 0) {
+		t.Error("advanced data version must be stale")
+	}
+	// Sentinel score 0 is never a valid hit (matches the score>0 rule).
+	if !base.isStale(SampleMeta{Score: 0}, listAt(0), 0) {
+		t.Error("zero score must be stale")
+	}
+
+	// maxAge: fresh within the window, stale past it.
+	aged := NewSampler[int]("x", base.loader, WithMaxAge[int](10*time.Second))
+	if aged.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), 1005) {
+		t.Error("within maxAge should be fresh")
+	}
+	if !aged.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), 1015) {
+		t.Error("past maxAge should be stale")
+	}
+
+	// shouldRefresh is additive: true forces a refresh even when fresh...
+	force := NewSampler[int]("x", base.loader, WithShouldRefresh[int](
+		func(SampleMeta, *ListResult) bool { return true }))
+	if !force.isStale(SampleMeta{Score: 100}, listAt(100), 0) {
+		t.Error("shouldRefresh=true must force a refresh")
+	}
+	// ...and false cannot suppress the data-version floor.
+	keep := NewSampler[int]("x", base.loader, WithShouldRefresh[int](
+		func(SampleMeta, *ListResult) bool { return false }))
+	if !keep.isStale(SampleMeta{Score: 100}, listAt(200), 0) {
+		t.Error("shouldRefresh=false must not override the data-version floor")
+	}
+}
+
+// TestSamplerFinalize verifies the error-handling contract: a loader error
+// is unwrapped (so caller errors.Is works), a fallback substitutes only
+// when it accepts the error, and non-loader (internal) errors propagate.
+func TestSamplerFinalize(t *testing.T) {
+	sentinel := errors.New("db down")
+
+	// No fallback: the original loader error surfaces, unwrapped.
+	plain := NewSampler[int]("x", func(*ListResult) (int, error) { return 0, nil })
+	if _, err := plain.finalize(0, &loaderError{err: sentinel}); !errors.Is(err, sentinel) {
+		t.Fatalf("expected unwrapped sentinel, got %v", err)
+	}
+
+	// Fallback default: substitutes a value, drops the error.
+	def := NewSampler[int]("x", plain.loader, WithLoaderErrorDefault[int](42))
+	if v, err := def.finalize(0, &loaderError{err: sentinel}); err != nil || v != 42 {
+		t.Fatalf("expected (42, nil), got (%d, %v)", v, err)
+	}
+
+	// Fallback that declines (ok=false) propagates the unwrapped error.
+	decline := NewSampler[int]("x", plain.loader, WithLoaderErrorFallback[int](
+		func(error) (int, bool) { return 0, false }))
+	if _, err := decline.finalize(0, &loaderError{err: sentinel}); !errors.Is(err, sentinel) {
+		t.Fatalf("declined fallback must propagate sentinel, got %v", err)
+	}
+
+	// A non-loader (internal) error is never eligible for the fallback.
+	internal := errors.New("marshal sample: boom")
+	if _, err := def.finalize(0, internal); !errors.Is(err, internal) {
+		t.Fatalf("internal error must propagate as-is, got %v", err)
+	}
+
+	// Happy path is a passthrough.
+	if v, err := def.finalize(7, nil); err != nil || v != 7 {
+		t.Fatalf("expected (7, nil), got (%d, %v)", v, err)
+	}
+}


### PR DESCRIPTION
## Summary

Refactor the sampling API from a stateless `Sample[T]` function to a reusable `Sampler[T]` type with a layered staleness policy. This enables fine-grained control over cache invalidation (data-version floor, max age, custom predicates) and error handling (loader-error fallbacks), while maintaining backward compatibility in behavior.

## Key Changes

- **New `Sampler[T]` type**: Construct once per `(indicator, T, loader)` and reuse across calls. Encapsulates the loader, staleness policy, and error handling strategy.

- **Layered staleness policy**:
  - Data-version floor (mandatory): recompute if catalog advanced past the cached version
  - `WithMaxAge(d)`: recompute if entry is older than `d` by Redis server clock (for time-sensitive derivations like "today" reports)
  - `WithShouldRefresh(fn)`: custom predicate (React's `shouldComponentUpdate` analog) to force recompute on cross-catalog dependencies or external inputs

- **Error handling options**:
  - `WithLoaderErrorFallback(fn)`: inspect loader errors and optionally substitute a value (transient, never cached)
  - `WithLoaderErrorDefault(v)`: always serve `v` on loader error
  - Loader errors are unwrapped so caller's `errors.Is` checks still work

- **Cache format upgrade**: `[score, data]` → `[score, updatedAt, data]` to support max-age checks. Legacy 2-element format fails to decode (forces recompute).

- **API surface**:
  - `NewSampler[T](indicator, loader, ...opts) *Sampler[T]`: constructor
  - `(*Sampler[T]).Sample(ctx, *ListResult) (T, error)`: single catalog (1 HGET on hit)
  - `(*Sampler[T]).Batch(ctx, map[string]*ListResult) map[string]*SampleResult[T]`: many catalogs (1 HMGET + concurrent loaders for misses)

- **Graceful degradation**: cache-read failures degrade to recompute; cache-write failures still return the freshly computed value (cache is an optimization, not the truth).

- **New `Reader.NowUnix()` method**: exposes Redis server clock (refreshed every 5s) for staleness checks; falls back to local clock during initial sync.

## Implementation Details

- `isStale()` enforces the staleness contract: data-version floor is mandatory, while `maxAge` and `shouldRefresh` can only *add* refresh triggers, never suppress one the data version requires.

- `loaderError` wrapper distinguishes loader errors from internal (encode/marshal) errors, so `finalize()` can scope the fallback correctly.

- `sampleCore()` handles the cache-or-compute path for a single catalog; `loadAndCache()` runs the loader under SingleFlight and stamps metadata.

- Batch path degrades gracefully on cache-read failure: emits an event and recomputes all misses rather than failing the entire batch.

- Comprehensive test coverage: codec round-trip, staleness layering, error handling contract, and per-catalog error isolation in batch mode.

https://claude.ai/code/session_01Qppu5sH52TbJoWzp3wPE1J