### PR TITLE
refactor!: unify Redis key layout as &lt;prefix&gt;:&lt;type&gt;:&lt;axis&gt;

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ hiccup) cannot freeze a degraded value into the cache until the next write.
 Cache-tier failures degrade gracefully too: a failed read recomputes, a
 failed write still returns the freshly computed value.
 
-**Storage layout**: samples live in `{prefix}:samples:{indicator}` Redis
+**Storage layout**: samples live in `{prefix}:m:{indicator}` Redis
 Hashes, each catalog a field holding a `[score, updatedAt, data]` JSON array
 (`score` = data version, `updatedAt` = compute time). All catalogs sharing one
 indicator are colocated, so indicator-wide enumeration / clearing is single-key.
@@ -296,7 +296,7 @@ retention concept; `ClearHistoryWithRetention` from earlier drafts is removed.
 
 | Function | File | Description |
 |----------|------|-------------|
-| `(*Client) AllSnaps(ctx) (map[string]SnapInfo, error)` | [snapshot.go](snapshot.go) | Single HGETALL on `<prefix>:snaps` returns every catalog's snap metadata |
+| `(*Client) AllSnaps(ctx) (map[string]SnapInfo, error)` | [snapshot.go](snapshot.go) | Single HGETALL on `<prefix>:s` returns every catalog's snap metadata |
 
 `AllSnaps` is intended for backup tooling: feed each `(catalog, StartTsSeq, StopTsSeq)`
 triple into `Storage.MakeSnapKey` to obtain the OSS object key, then copy that
@@ -497,20 +497,23 @@ back later. Callers must therefore avoid `:` and `|` in catalog names today.
 ### Redis index
 
 ```
-{prefix}:{catalog}:delta   ZSet
+{prefix}:d:{catalog}       ZSet     # delta — per-catalog change log
   score  = timestamp + seqid / 1e6   (e.g. 1700000000.000123)
   member = "delta|{mergeType}|{path}|{ts}_{seqid}|{uuid}"
 
-{prefix}:snaps             Hash    field=catalog
+{prefix}:s                 Hash     # snap — deployment-wide, field = catalog
   value = "{stopTsSeq}"                         # one entry per catalog,
                                                 # overwritten on each save;
                                                 # HGETALL drives backup tooling
 
-{prefix}:samples:{indicator}   Hash
-  field = catalog
+{prefix}:m:{indicator}     Hash     # sample (memo) — per-indicator, field = catalog
   value = [score, updatedAt, data]              # JSON array, atomic per HSET
                                                 # score=data version, updatedAt=compute time
 ```
+
+All three follow a uniform `<prefix>:<type>:<axis>` layout — `d` delta,
+`s` snap, `m` sample (memo). The snap key has no third token because it
+is a singleton: the per-catalog axis lives as the Hash *field* inside.
 
 ### Object storage
 
@@ -615,16 +618,20 @@ v3 is **not** wire-compatible with v2 callers. Concretely:
   `shouldUpdated` callback and `motionCatalogs` cross-catalog sampling.
 - **Sample storage layout inverted.** v2 used
   `{prefix}:{catalog}:sample` Hashes with the indicator as the field. v3 uses
-  `{prefix}:samples:{indicator}` Hashes with the catalog as the field. v2
-  cache entries cannot be read by v3 and will be silently recomputed.
+  `{prefix}:m:{indicator}` Hashes with the catalog as the field. v2 cache
+  entries cannot be read by v3 and will be silently recomputed.
 - **Snap storage replaced.** v2 stored snap metadata in per-catalog ZSets
   (`{prefix}:{catalog}:snap`) and tracked historical snapshots via a retention
   parameter. v3 stores a single latest snap per catalog as a field of one
-  global Hash (`{prefix}:snaps`), enabling whole-deployment backup via one
+  global Hash (`{prefix}:s`), enabling whole-deployment backup via one
   HGETALL. The previous OSS snap object on each save becomes orphan storage
   (acceptable trade-off; reaped by future SweepOrphans tooling).
   `ClearHistoryWithRetention(ctx, catalog, keepSnaps)` is removed —
   use `ClearHistory(ctx, catalog)` instead.
+- **Delta key shape** changed to a `<type>:<axis>` layout, matching snap
+  and sample: `{prefix}:{catalog}:delta` → `{prefix}:d:{catalog}`. Existing
+  v3-alpha delta zsets are not visible after upgrade; flush and let writers
+  repopulate (delta bodies in OSS are untouched).
 - **`Client.AllSnaps(ctx)`** is new: returns every catalog's snap metadata in
   one HGETALL, intended for backup workflows.
 - **`merge.Merge` signature** changed: dropped the unused `catalog` parameter

--- a/internal/index/encoding.go
+++ b/internal/index/encoding.go
@@ -82,7 +82,7 @@ func DecodeDeltaMember(member string, score float64) (*DeltaInfo, error) {
 }
 
 // EncodeSnapValue / DecodeSnapValue handle the value stored under
-// "<prefix>:snaps", keyed by catalog. The value is just "{stopTsSeq}".
+// "<prefix>:s", keyed by catalog. The value is just "{stopTsSeq}".
 func EncodeSnapValue(stopTsSeq TimeSeqID) string { return stopTsSeq.String() }
 
 func DecodeSnapValue(value string) (TimeSeqID, error) {

--- a/internal/index/indexIO.go
+++ b/internal/index/indexIO.go
@@ -23,22 +23,23 @@ func (w *indexIO) requirePrefix() {
 	}
 }
 
-// MakeDeltaZsetKey: per-catalog delta ZSet "<prefix>:<catalog>:delta".
+// MakeDeltaZsetKey: per-catalog delta ZSet "<prefix>:d:<catalog>".
 func (w *indexIO) MakeDeltaZsetKey(catalog string) string {
 	w.requirePrefix()
-	return fmt.Sprintf("%s:%s:delta", w.prefix, encode.EncodeRedisCatalogName(catalog))
+	return fmt.Sprintf("%s:d:%s", w.prefix, encode.EncodeRedisCatalogName(catalog))
 }
 
-// MakeSnapsHashKey: deployment-wide snap Hash "<prefix>:snaps", with
-// catalog as field. One HMGet/HGETALL surfaces every snap at once.
+// MakeSnapsHashKey: deployment-wide snap Hash "<prefix>:s", with catalog
+// as field. One HMGet/HGETALL surfaces every snap at once.
 func (w *indexIO) MakeSnapsHashKey() string {
 	w.requirePrefix()
-	return fmt.Sprintf("%s:snaps", w.prefix)
+	return fmt.Sprintf("%s:s", w.prefix)
 }
 
 // MakeSampleIndicatorKey: per-indicator sample Hash
-// "<prefix>:samples:<indicator>", with catalog as field.
+// "<prefix>:m:<indicator>", with catalog as field. "m" reads as "memo" —
+// a sample is the memoised output of a derived computation.
 func (w *indexIO) MakeSampleIndicatorKey(indicator string) string {
 	w.requirePrefix()
-	return fmt.Sprintf("%s:samples:%s", w.prefix, encode.EncodeRedisCatalogName(indicator))
+	return fmt.Sprintf("%s:m:%s", w.prefix, encode.EncodeRedisCatalogName(indicator))
 }

--- a/internal/index/reader_snap_hash_test.go
+++ b/internal/index/reader_snap_hash_test.go
@@ -31,8 +31,8 @@ func snapHashTestRedis(t *testing.T) *redis.Client {
 }
 
 // TestSnapHashRoundTrip exercises the AddSnap → HGet path on the real
-// Redis Hash and verifies the layout is "<prefix>:snaps" with catalog
-// as field, value = "{stopTsSeq}".
+// Redis Hash and verifies the layout is "<prefix>:s" with catalog as
+// field, value = "{stopTsSeq}".
 func TestSnapHashRoundTrip(t *testing.T) {
 	rdb := snapHashTestRedis(t)
 	w := NewWriter(rdb)
@@ -47,7 +47,7 @@ func TestSnapHashRoundTrip(t *testing.T) {
 		t.Fatalf("AddSnap: %v", err)
 	}
 
-	val, err := rdb.HGet(ctx, "test:snaps", "users").Result()
+	val, err := rdb.HGet(ctx, "test:s", "users").Result()
 	if err != nil {
 		t.Fatalf("HGet: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestSnapHashOverwrite(t *testing.T) {
 		t.Fatalf("after overwrite: got %+v, want stop=%v", got, stop2)
 	}
 
-	cnt, err := rdb.HLen(ctx, "test:snaps").Result()
+	cnt, err := rdb.HLen(ctx, "test:s").Result()
 	if err != nil {
 		t.Fatalf("HLen: %v", err)
 	}

--- a/internal/index/writer_snap.go
+++ b/internal/index/writer_snap.go
@@ -17,7 +17,7 @@ func NewWriter(rdb *redis.Client) *Writer {
 	return &Writer{rdb: rdb}
 }
 
-// AddSnap upserts the catalog's snap entry in "<prefix>:snaps".
+// AddSnap upserts the catalog's snap entry in "<prefix>:s".
 // HSet overwrites any prior entry; the previous OSS snap object is
 // left orphan in storage (V3 contract).
 func (w *Writer) AddSnap(ctx context.Context, catalog string, stopTsSeq TimeSeqID) error {

--- a/sample.go
+++ b/sample.go
@@ -15,7 +15,7 @@ import (
 //
 // A "sample" is a value of type T computed from a catalog's raw state
 // (snap + deltas) by a loader, then memoised in the
-// "<prefix>:samples:<indicator>" Redis Hash (catalog = field). Construct
+// "<prefix>:m:<indicator>" Redis Hash (catalog = field). Construct
 // one Sampler per (indicator, T, loader) and reuse it: the staleness
 // policy and error fallback are bound at construction so every call site
 // stays uniform.

--- a/snapshot.go
+++ b/snapshot.go
@@ -8,7 +8,7 @@ import (
 )
 
 // AllSnaps returns the latest snap metadata for every catalog in this
-// deployment in a single Redis HGETALL on "<prefix>:snaps". Backup
+// deployment in a single Redis HGETALL on "<prefix>:s". Backup
 // tooling can feed each (catalog, info.StopTsSeq) into
 // Storage.MakeSnapKey to enumerate every OSS snap key without a LIST.
 func (c *Client) AllSnaps(ctx context.Context) (map[string]SnapInfo, error) {


### PR DESCRIPTION
## Summary

Unify all three index keys under one shape — type token right after the
prefix, per-thing axis last (or absent for the snap singleton) — and
abbreviate the type tokens to single letters. The old layout had snap and
sample putting the type at the front and delta putting it at the back, plus
spelled-out tokens (`snaps`, `samples`, `delta`) that were the largest
piece of every key string.

| | Before | After |
|-|--------|-------|
| delta | `{prefix}:{catalog}:delta` | `{prefix}:d:{catalog}` |
| snap | `{prefix}:snaps` | `{prefix}:s` |
| sample | `{prefix}:samples:{indicator}` | `{prefix}:m:{indicator}` |

## Why this shape

- **Discoverability.** `SCAN MATCH "<prefix>:d:*"` (or `:m:*`) enumerates
  one family by type. With delta's type token trailing, that was awkward.
- **Mental-model parity.** The Sampler refactor (#2) made the categorical
  axes explicit: snap = deployment-wide raw frozen state; sample =
  per-indicator derived (memoised); delta = per-catalog raw change log.
  Key shape now mirrors that — type first, axis second — instead of
  carrying the historical accident of when each key was introduced.
- **Density.** The type token was the longest piece of every key string,
  conveying no information not already carried by the type-specific
  generator function. Single-letter tokens collapse that overhead by
  ~80% with no readability loss in code (the `MakeXxxKey` helpers name
  the type explicitly).

## Why these letters

- `d` delta, `s` snap — first letter, unambiguous.
- `m` sample — `s` is taken by snap, and `m` reads as **memo**: Sampler
  is the memoisation layer over derived computation (the framing the
  codebase already uses; see `sample.go` header). Using `m` makes that
  nature visible in the key.

## Why snap drops the third token

Snap is a singleton hash; its per-catalog axis lives as the Hash field,
not as a key segment. `{prefix}:s` makes that explicit — there is no
axis to put in the key. (Previously written `{prefix}:snaps` — the
trailing `s` carried no information.)

## Not touched

- The seqid Lua counter `{prefix}:seqid:{catalog}:{ts}` in `writer_atomic.go`
  — different beast (per-(catalog, second) INCR target, not a type family).
- Top-level `lake.setting` config key, `lake:seqid` counter — unchanged.

## ⚠️ BREAKING (v3 alpha)

Existing v3-alpha deployments cannot read their old keys after this upgrade:

| Family | Recovery |
|--------|----------|
| **Snap** | Automatic. Snap is idempotent and self-correcting — the next read regenerates from OSS (existing v3 contract). |
| **Sample** | Harmless. Old `{prefix}:samples:*` hashes become unreachable; entries re-derive on the next `Sampler` call. |
| **Delta** | **Operator action required.** Old `{prefix}:{catalog}:delta` zsets are not visible; delta bodies in OSS are untouched but Lake cannot find them without the zset. On a live system: drain writes, sweep-rebuild `{prefix}:d:{catalog}` from OSS delta objects (the path/mergeType/uuid metadata is in OSS user metadata), then resume. |

README migration section updated accordingly.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test -race -count=1 .` and `./internal/index` pass.
- `reader_snap_hash_test.go` updated to assert the new `test:s` hash.
- Three unrelated test files (`encoding_test.go`, `replace_test.go`,
  `validate_catalog_test.go`) are flagged by `gofmt` — pre-existing on
  `main`, not this PR's concern.
- Zero residual references to the old layout in code or README
  (migration notes describe historical layouts and are intentionally
  preserved; the v2 entry now also reflects the new v3 shape).

## Test plan

- [ ] Local Redis run — confirm `SCAN MATCH "lake:d:*" / ":m:*" / "lake:s"` shows the expected new keys.
- [ ] Confirm `Sampler.Sample` / `Sampler.Batch` round-trip works against the new `:m:` hash.
- [ ] Confirm `AllSnaps` round-trip works against the new `:s` hash.

https://claude.ai/code/session_01Qppu5sH52TbJoWzp3wPE1J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qppu5sH52TbJoWzp3wPE1J)_