### PR TITLE
feat: sample cache-tier separation, peer-aware refresh, HSCAN snap iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ import "github.com/hkloudou/lake/v3"
 | `WithDeltaCacheMetaURL(url, ttl) func(*option)` | [lake.go](lake.go) | Use a separate Redis for delta cache |
 | `WithSnapCache(cache.Cache) func(*option)` | [lake.go](lake.go) | Provide a `cache.Cache` directly |
 | `WithDeltaCache(cache.Cache) func(*option)` | [lake.go](lake.go) | Same, for delta cache |
+| `WithSampleCacheURL(url) func(*option)` | [lake.go](lake.go) | Route the Sampler memo hash (`<prefix>:m:*`) to a separate Redis |
+| `WithSampleCacheRedis(*redis.Client) func(*option)` | [lake.go](lake.go) | Same, with a caller-managed `*redis.Client` |
 | `(*Client) Use(handler EventHandler)` | [middleware.go](middleware.go) | Register an event handler |
 
 ### Write — three-step direct upload
@@ -262,10 +264,36 @@ report, err := sampler.Sample(ctx, list)
    Redis server clock. For time-sensitive derivations (a "today" report is
    correct only for today, not forever).
 3. **`WithShouldRefresh(fn)`** — a custom predicate, the analog of React's
-   `shouldComponentUpdate`: return `true` to force a recompute even when the
-   data version is unchanged (cross-catalog dependencies, external inputs).
-   It runs on every cache hit, so it must be pure and cheap — no I/O; compare
-   versions you already hold (e.g. from the same `BatchList`).
+   `shouldComponentUpdate`. Signature:
+   ```go
+   func(meta SampleMeta, self *ListResult, peers map[string]*ListResult) bool
+   ```
+   Returns `true` to force a recompute even when the data version is
+   unchanged (cross-catalog dependencies, external inputs). `peers` is the
+   full set of `ListResult`s available in the current call's context —
+   `BatchList`'s lists map for `Sampler.Batch`, a singleton `{self.catalog:
+   self}` for `Sampler.Sample`. **Runs on every cache hit**, so it must be
+   pure and cheap (no I/O); compare versions already in hand.
+
+   Cross-catalog example — `A` depends on `B`, both sampled in one batch:
+   ```go
+   type Report struct {
+       Value     int
+       BSeenAt   float64 // version of B this report was computed against
+   }
+   sampler := lake.NewSampler[Report]("daily", loadReport,
+       lake.WithShouldRefresh(func(_ lake.SampleMeta, _ *lake.ListResult, peers map[string]*lake.ListResult) bool {
+           // Refresh A when B has moved past the version A recorded as its dependency.
+           // The cached Report carries BSeenAt; loader populates it at compute time.
+           // Read it back off T inside the predicate via your own decode path,
+           // or store it on SampleMeta via a richer wrapper.
+           b, ok := peers["B"]
+           return ok && b.LastUpdated() > /* the BSeenAt you stamped */ 0
+       }),
+   )
+   lists := client.BatchList(ctx, []string{"A", "B"})
+   results := sampler.Batch(ctx, lists)
+   ```
 
 These triggers can only *add* recomputes; none serves a value older than the
 data-version floor allows.
@@ -282,6 +310,15 @@ Hashes, each catalog a field holding a `[score, updatedAt, data]` JSON array
 (`score` = data version, `updatedAt` = compute time). All catalogs sharing one
 indicator are colocated, so indicator-wide enumeration / clearing is single-key.
 
+**Cache-tier separation (optional but recommended at scale).** The Sampler
+memo hash can live on a dedicated Redis instance via
+`lake.WithSampleCacheURL(...)` / `lake.WithSampleCacheRedis(rdb)`. Sample is
+a derived cache — outage, scan, restart, or flush of the cache tier merely
+recomputes; the authoritative Redis (snap, delta, seqid) never depends on
+cache health. This narrows the "must-not-lose" Redis surface to a small
+metadata working set and lets the cache tier scale on its own dimensions
+(memory, CPU). Defaults to the authoritative Redis when omitted.
+
 ### Cleanup
 
 | Function | File | Description |
@@ -296,13 +333,29 @@ retention concept; `ClearHistoryWithRetention` from earlier drafts is removed.
 
 | Function | File | Description |
 |----------|------|-------------|
-| `(*Client) AllSnaps(ctx) (map[string]SnapInfo, error)` | [snapshot.go](snapshot.go) | Single HGETALL on `<prefix>:s` returns every catalog's snap metadata |
+| `(*Client) AllSnaps(ctx) (map[string]SnapInfo, error)` | [snapshot.go](snapshot.go) | Collect every catalog's snap into a map via HSCAN |
+| `(*Client) IterateSnaps(ctx, fn) error` | [snapshot.go](snapshot.go) | Stream each `(catalog, snap)` to `fn`; stops when `fn` returns false |
 
-`AllSnaps` is intended for backup tooling: feed each `(catalog, StartTsSeq, StopTsSeq)`
-triple into `Storage.MakeSnapKey` to obtain the OSS object key, then copy that
-object to your archive bucket. This avoids a full OSS `LIST`, which is slow and
-paginated, and gives you a consistent snapshot of the deployment in one Redis
-round-trip.
+`AllSnaps` is the convenient form for small to moderate fleets: it walks
+`<prefix>:s` via HSCAN under the hood and accumulates every entry into a
+map. For very large deployments — or any case where you don't want the
+full map in memory — use `IterateSnaps`, which yields one entry at a time
+and honours early termination.
+
+Both forms avoid a full OSS `LIST`, which is slow and paginated. Neither
+form ever issues a single Redis op that blocks the server's main thread for
+more than ~500 fields, so even a million-catalog hash backs up without
+stalling concurrent reads and writes. Feed each `(catalog, StopTsSeq)` into
+`Storage.MakeSnapKey` to obtain the OSS object key, then copy that object to
+your archive bucket.
+
+```go
+// Streaming, budget-friendly backup loop.
+err := client.IterateSnaps(ctx, func(catalog string, snap lake.SnapInfo) bool {
+    ossKey := storage.MakeSnapKey(catalog, snap.StopTsSeq)
+    return copyToArchive(ctx, ossKey) == nil // stop on first failure
+})
+```
 
 ### Examples
 

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -96,19 +96,60 @@ func (r *Reader) GetLatestSnap(ctx context.Context, catalog string) (*SnapInfo, 
 	return &SnapInfo{StopTsSeq: stop}, nil
 }
 
-// AllSnaps returns every catalog's snap metadata via a single HGETALL.
-func (r *Reader) AllSnaps(ctx context.Context) (map[string]SnapInfo, error) {
-	all, err := r.rdb.HGetAll(ctx, r.MakeSnapsHashKey()).Result()
-	if err != nil {
-		return nil, err
-	}
-	out := make(map[string]SnapInfo, len(all))
-	for catalog, val := range all {
-		if stop, err := DecodeSnapValue(val); err == nil {
-			out[catalog] = SnapInfo{StopTsSeq: stop}
+// snapScanBatch is the HSCAN page size. Tuned so each Redis call returns
+// in well under a millisecond on the server (single-threaded event loop
+// tolerates ~10⁴ small fields per op without noticeable jitter); larger
+// values trade pipeline depth for hash-table coverage per page.
+const snapScanBatch = 500
+
+// IterateSnaps streams every catalog's snap to fn via HSCAN — no single
+// Redis op holds the server's main thread for more than ~snapScanBatch
+// fields, so this scales to multi-million-catalog deployments without
+// stalling concurrent reads/writes. Iteration stops when fn returns false
+// or the hash is exhausted; ctx cancellation is honoured between pages.
+//
+// Each (catalog, snap) is yielded at most once for snap values that
+// existed throughout the scan; a catalog that is added or removed *during*
+// the scan may be observed once, twice, or not at all (HSCAN's standard
+// concurrent-modification semantics). Values that fail to decode are
+// skipped silently.
+func (r *Reader) IterateSnaps(ctx context.Context, fn func(catalog string, snap SnapInfo) bool) error {
+	key := r.MakeSnapsHashKey()
+	var cursor uint64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
+		pairs, next, err := r.rdb.HScan(ctx, key, cursor, "", snapScanBatch).Result()
+		if err != nil {
+			return err
+		}
+		for i := 0; i+1 < len(pairs); i += 2 {
+			stop, derr := DecodeSnapValue(pairs[i+1])
+			if derr != nil {
+				continue
+			}
+			if !fn(pairs[i], SnapInfo{StopTsSeq: stop}) {
+				return nil
+			}
+		}
+		if next == 0 {
+			return nil
+		}
+		cursor = next
 	}
-	return out, nil
+}
+
+// AllSnaps collects every catalog's snap into a map. Convenience over
+// IterateSnaps for small / moderate deployments; for very large fleets,
+// prefer IterateSnaps to avoid materialising the full map at once.
+func (r *Reader) AllSnaps(ctx context.Context) (map[string]SnapInfo, error) {
+	out := make(map[string]SnapInfo)
+	err := r.IterateSnaps(ctx, func(catalog string, snap SnapInfo) bool {
+		out[catalog] = snap
+		return true
+	})
+	return out, err
 }
 
 // BatchList runs an HMGet on snaps + a pipelined ZRange for every

--- a/internal/index/reader_snap_hash_test.go
+++ b/internal/index/reader_snap_hash_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -108,9 +109,9 @@ func TestSnapHashOverwrite(t *testing.T) {
 	}
 }
 
-// TestAllSnapsBatchBackup is the headline use-case test: HGETALL returns
-// every catalog's snap in one call so backup tooling can enumerate the
-// full set of OSS snap keys without an OSS LIST.
+// TestAllSnapsBatchBackup is the headline use-case test: AllSnaps (via
+// HSCAN under the hood) returns every catalog's snap so backup tooling
+// can enumerate the full set of OSS snap keys without an OSS LIST.
 func TestAllSnapsBatchBackup(t *testing.T) {
 	rdb := snapHashTestRedis(t)
 	w := NewWriter(rdb)
@@ -163,5 +164,36 @@ func TestGetLatestSnapMissingReturnsNilNil(t *testing.T) {
 	}
 	if got != nil {
 		t.Fatalf("expected nil SnapInfo, got %+v", got)
+	}
+}
+
+// TestIterateSnapsEarlyStop confirms IterateSnaps honours fn returning
+// false (caller stops iteration mid-stream) without consuming the whole
+// hash — the property backup tools rely on for budgeted scans.
+func TestIterateSnapsEarlyStop(t *testing.T) {
+	rdb := snapHashTestRedis(t)
+	w := NewWriter(rdb)
+	r := NewReader(rdb)
+	w.SetPrefix("test")
+	r.SetPrefix("test")
+
+	ctx := context.Background()
+	for i := 0; i < 50; i++ {
+		cat := fmt.Sprintf("c%02d", i)
+		if err := w.AddSnap(ctx, cat, TimeSeqID{Timestamp: 1700000000 + int64(i), SeqID: 1}); err != nil {
+			t.Fatalf("AddSnap %s: %v", cat, err)
+		}
+	}
+
+	var seen int
+	err := r.IterateSnaps(ctx, func(string, SnapInfo) bool {
+		seen++
+		return seen < 3 // request stop after the 3rd item
+	})
+	if err != nil {
+		t.Fatalf("IterateSnaps: %v", err)
+	}
+	if seen != 3 {
+		t.Fatalf("early-stop: callback ran %d times, want 3", seen)
 	}
 }

--- a/lake.go
+++ b/lake.go
@@ -22,7 +22,8 @@ import (
 // snapshot saves are fire-and-forget (an interrupted save leaves at
 // most one orphan OSS object, reaped by the next sweep).
 type Client struct {
-	rdb        *redis.Client
+	rdb        *redis.Client // authoritative: snap hash, delta zset, seqid
+	sampleRdb  *redis.Client // sample (memo) hash; defaults to rdb. Pluggable so cache-tier failures cannot threaten the authoritative store.
 	writer     *index.Writer
 	reader     *index.Reader
 	configMgr  *config.Manager
@@ -44,6 +45,7 @@ type option struct {
 	Storage            storage.Storage
 	SnapCacheProvider  cache.Cache
 	DeltaCacheProvider cache.Cache
+	SampleRdb          *redis.Client // nil → use the authoritative rdb
 }
 
 // NewLake creates a Lake client. Config (storage backend, bucket, etc.)
@@ -65,9 +67,13 @@ func NewLake(metaUrl string, opts ...func(*option)) *Client {
 	if o.DeltaCacheProvider == nil {
 		o.DeltaCacheProvider = cache.NewMemoryCache(1 * time.Minute)
 	}
+	if o.SampleRdb == nil {
+		o.SampleRdb = rdb // colocated by default
+	}
 
 	return &Client{
 		rdb:          rdb,
+		sampleRdb:    o.SampleRdb,
 		writer:       index.NewWriter(rdb),
 		reader:       index.NewReader(rdb),
 		configMgr:    config.NewManager(rdb),
@@ -100,6 +106,25 @@ func WithDeltaCacheMetaURL(metaUrl string, ttl time.Duration) func(*option) {
 		panic(err)
 	}
 	return WithDeltaCache(c)
+}
+
+// WithSampleCacheRedis routes the Sampler memo hash ("<prefix>:m:*") to a
+// separate Redis instance instead of the authoritative one. Sample is a
+// derived cache — a separate hot tier can absorb scan / flush / restart
+// without threatening the authoritative store. Defaults to the
+// authoritative rdb when omitted.
+func WithSampleCacheRedis(rdb *redis.Client) func(*option) {
+	return func(o *option) { o.SampleRdb = rdb }
+}
+
+// WithSampleCacheURL is the URL form of WithSampleCacheRedis. Panics on
+// an invalid URL (programmer error at construction time, per package policy).
+func WithSampleCacheURL(url string) func(*option) {
+	opt, err := redis.ParseURL(url)
+	if err != nil {
+		panic(fmt.Errorf("lake: invalid sample-cache URL: %w", err))
+	}
+	return WithSampleCacheRedis(redis.NewClient(opt))
 }
 
 // ensureInitialized loads lake.setting on first use and wires the

--- a/sample.go
+++ b/sample.go
@@ -31,11 +31,16 @@ import (
 // and any fallback substituted for it, is returned to the caller but
 // never written back — so a transient failure cannot poison the cache
 // until the catalog's next write.
+//
+// Physically the memo Hash may live on a dedicated cache-tier Redis
+// (Client option WithSampleCacheRedis / WithSampleCacheURL); a cache
+// Redis outage degrades gracefully — reads recompute, writes are
+// best-effort — so the authoritative store never depends on cache health.
 type Sampler[T any] struct {
 	indicator     string
 	loader        func(*ListResult) (T, error)
 	maxAge        time.Duration
-	shouldRefresh func(SampleMeta, *ListResult) bool
+	shouldRefresh func(SampleMeta, *ListResult, map[string]*ListResult) bool
 	onLoaderErr   func(error) (T, bool)
 }
 
@@ -88,14 +93,27 @@ func WithMaxAge[T any](d time.Duration) SamplerOption[T] {
 }
 
 // WithShouldRefresh installs a custom staleness predicate — the analog of
-// React's shouldComponentUpdate. It receives the cached entry's metadata
-// and the current list and returns true to force a recompute even when the
-// data version is unchanged (cross-catalog dependencies, external inputs).
+// React's shouldComponentUpdate. It receives:
 //
-// It runs on every cache hit, so it MUST be pure and cheap: do no I/O.
-// Cross-catalog dependencies should compare versions already in hand
-// (e.g. fetched by the same BatchList), never fetch them here.
-func WithShouldRefresh[T any](fn func(SampleMeta, *ListResult) bool) SamplerOption[T] {
+//   - meta:  the cached entry's metadata (its data version and compute time)
+//   - self:  this catalog's current ListResult
+//   - peers: every ListResult available in the current call's context. For
+//     Sampler.Batch this is the full lists map (including self under its
+//     own key); for Sampler.Sample it is a singleton {self.catalog: self}.
+//     Never nil.
+//
+// Returns true to force a recompute even when the data version is unchanged
+// (cross-catalog dependencies, external inputs). Runs on every cache hit,
+// so it MUST be pure and cheap: do no I/O.
+//
+// To act on a cross-catalog dependency, fan out a single BatchList covering
+// the catalogs you care about, then compare peers["B"].LastUpdated() against
+// whatever version of B the cached T recorded at compute time (T is the
+// natural place to carry "what I depended on" — Sampler does not track it).
+// If the relevant peer is absent from peers, the dependency cannot be
+// evaluated this call; either return false (accept the stale value this
+// time) or arrange for BatchList to include it next time.
+func WithShouldRefresh[T any](fn func(meta SampleMeta, self *ListResult, peers map[string]*ListResult) bool) SamplerOption[T] {
 	return func(s *Sampler[T]) { s.shouldRefresh = fn }
 }
 
@@ -131,7 +149,9 @@ func (s *Sampler[T]) Sample(ctx context.Context, list *ListResult) (T, error) {
 	if err := c.ensureInitialized(ctx); err != nil {
 		return zero, err
 	}
-	return s.finalize(s.sampleCore(ctx, c, list))
+	// Single-catalog context: the only "peer" available is self.
+	peers := map[string]*ListResult{list.catalog: list}
+	return s.finalize(s.sampleCore(ctx, c, list, peers))
 }
 
 // Batch fetches the same indicator for many catalogs in one HMGet, running
@@ -194,7 +214,7 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 	now := c.reader.NowUnix()
 	hashKey := c.reader.MakeSampleIndicatorKey(s.indicator)
 
-	cached, err := c.rdb.HMGet(ctx, hashKey, probe...).Result()
+	cached, err := c.sampleRdb.HMGet(ctx, hashKey, probe...).Result()
 	if err != nil && err != redis.Nil {
 		// Cache-read failure: degrade to recompute-all rather than fail
 		// the batch (the cache is an optimization, not the truth).
@@ -212,7 +232,7 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 		cat := probe[i]
 		l := lists[cat]
 		if str, ok := raw.(string); ok {
-			if meta, data, derr := unmarshalSampleCache[T]([]byte(str)); derr == nil && !s.isStale(meta, l, now) {
+			if meta, data, derr := unmarshalSampleCache[T]([]byte(str)); derr == nil && !s.isStale(meta, l, lists, now) {
 				out[cat] = &SampleResult[T]{Value: data}
 				continue
 			}
@@ -251,7 +271,7 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 // isStale decides whether a cached entry must be recomputed. The data-
 // version floor is mandatory; maxAge and shouldRefresh only ADD triggers
 // (they can force a refresh, never suppress one the data version requires).
-func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, now int64) bool {
+func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, peers map[string]*ListResult, now int64) bool {
 	lastUpdated := list.LastUpdated()
 	if !(meta.Score >= lastUpdated && meta.Score > 0) {
 		return true // data advanced past the cached version (or none) → refresh
@@ -259,7 +279,7 @@ func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, now int64) bool 
 	if s.maxAge > 0 && now > 0 && meta.UpdatedAt > 0 && now-meta.UpdatedAt >= int64(s.maxAge.Seconds()) {
 		return true
 	}
-	if s.shouldRefresh != nil && s.shouldRefresh(meta, list) {
+	if s.shouldRefresh != nil && s.shouldRefresh(meta, list, peers) {
 		return true
 	}
 	return false
@@ -268,13 +288,13 @@ func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, now int64) bool 
 // sampleCore is the cache-or-compute path for a single catalog: one HGET,
 // then load on miss/stale. A cache-READ failure degrades to recompute — it
 // never fails the call.
-func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult) (T, error) {
+func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult, peers map[string]*ListResult) (T, error) {
 	lastUpdated := list.LastUpdated()
 	now := c.reader.NowUnix()
 	hashKey := c.reader.MakeSampleIndicatorKey(s.indicator)
 
-	if cached, err := c.rdb.HGet(ctx, hashKey, list.catalog).Bytes(); err == nil {
-		if meta, data, derr := unmarshalSampleCache[T](cached); derr == nil && !s.isStale(meta, list, now) {
+	if cached, err := c.sampleRdb.HGet(ctx, hashKey, list.catalog).Bytes(); err == nil {
+		if meta, data, derr := unmarshalSampleCache[T](cached); derr == nil && !s.isStale(meta, list, peers, now) {
 			return data, nil
 		}
 	} else if err != redis.Nil {
@@ -300,7 +320,7 @@ func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResu
 		if merr != nil {
 			return "", fmt.Errorf("marshal sample: %w", merr)
 		}
-		if werr := c.rdb.HSet(ctx, hashKey, list.catalog, data).Err(); werr != nil {
+		if werr := c.sampleRdb.HSet(ctx, hashKey, list.catalog, data).Err(); werr != nil {
 			c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hset", "err": werr.Error()})
 		}
 		return string(data), nil

--- a/sample_batch_redis_test.go
+++ b/sample_batch_redis_test.go
@@ -61,7 +61,7 @@ func TestBatchSample_HitsAndMisses_Redis(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 	hashKey := c.reader.MakeSampleIndicatorKey("daily")
-	if err := c.rdb.HSet(ctx, hashKey, "users", primed).Err(); err != nil {
+	if err := c.sampleRdb.HSet(ctx, hashKey, "users", primed).Err(); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -102,7 +102,7 @@ func TestBatchSample_HitsAndMisses_Redis(t *testing.T) {
 		}
 	}
 
-	cnt, err := c.rdb.HLen(ctx, hashKey).Result()
+	cnt, err := c.sampleRdb.HLen(ctx, hashKey).Result()
 	if err != nil {
 		t.Fatalf("HLen: %v", err)
 	}

--- a/sample_test.go
+++ b/sample_test.go
@@ -43,40 +43,78 @@ func TestSampleCacheCodec(t *testing.T) {
 // refresh triggers — never suppress one the data version requires.
 func TestSamplerIsStale(t *testing.T) {
 	base := NewSampler[int]("x", func(*ListResult) (int, error) { return 0, nil })
+	noPeers := map[string]*ListResult(nil) // tests don't exercise peers here
 
 	// Floor satisfied: cached version >= current, positive → fresh.
-	if base.isStale(SampleMeta{Score: 100}, listAt(100), 0) {
+	if base.isStale(SampleMeta{Score: 100}, listAt(100), noPeers, 0) {
 		t.Error("equal version should be fresh")
 	}
 	// Data advanced → stale regardless of anything else.
-	if !base.isStale(SampleMeta{Score: 100}, listAt(200), 0) {
+	if !base.isStale(SampleMeta{Score: 100}, listAt(200), noPeers, 0) {
 		t.Error("advanced data version must be stale")
 	}
 	// Sentinel score 0 is never a valid hit (matches the score>0 rule).
-	if !base.isStale(SampleMeta{Score: 0}, listAt(0), 0) {
+	if !base.isStale(SampleMeta{Score: 0}, listAt(0), noPeers, 0) {
 		t.Error("zero score must be stale")
 	}
 
 	// maxAge: fresh within the window, stale past it.
 	aged := NewSampler[int]("x", base.loader, WithMaxAge[int](10*time.Second))
-	if aged.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), 1005) {
+	if aged.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), noPeers, 1005) {
 		t.Error("within maxAge should be fresh")
 	}
-	if !aged.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), 1015) {
+	if !aged.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), noPeers, 1015) {
 		t.Error("past maxAge should be stale")
 	}
 
 	// shouldRefresh is additive: true forces a refresh even when fresh...
 	force := NewSampler[int]("x", base.loader, WithShouldRefresh[int](
-		func(SampleMeta, *ListResult) bool { return true }))
-	if !force.isStale(SampleMeta{Score: 100}, listAt(100), 0) {
+		func(SampleMeta, *ListResult, map[string]*ListResult) bool { return true }))
+	if !force.isStale(SampleMeta{Score: 100}, listAt(100), noPeers, 0) {
 		t.Error("shouldRefresh=true must force a refresh")
 	}
 	// ...and false cannot suppress the data-version floor.
 	keep := NewSampler[int]("x", base.loader, WithShouldRefresh[int](
-		func(SampleMeta, *ListResult) bool { return false }))
-	if !keep.isStale(SampleMeta{Score: 100}, listAt(200), 0) {
+		func(SampleMeta, *ListResult, map[string]*ListResult) bool { return false }))
+	if !keep.isStale(SampleMeta{Score: 100}, listAt(200), noPeers, 0) {
 		t.Error("shouldRefresh=false must not override the data-version floor")
+	}
+}
+
+// TestSamplerCrossCatalogRefresh: the shouldRefresh predicate can read
+// a peer's LastUpdated() and force a recompute when the peer has moved
+// past the version the sample recorded as its dependency baseline.
+func TestSamplerCrossCatalogRefresh(t *testing.T) {
+	// Sentinel for "the sample was computed assuming peer B at version 50".
+	const baselineB = 50.0
+
+	sampler := NewSampler[int]("x",
+		func(*ListResult) (int, error) { return 0, nil },
+		WithShouldRefresh[int](func(_ SampleMeta, _ *ListResult, peers map[string]*ListResult) bool {
+			b := peers["B"]
+			return b != nil && b.LastUpdated() > baselineB
+		}),
+	)
+	meta := SampleMeta{Score: 100} // self's data version unchanged
+
+	// Peer B still at baseline → fresh.
+	peers := map[string]*ListResult{"A": listAt(100), "B": listAt(baselineB)}
+	if sampler.isStale(meta, peers["A"], peers, 0) {
+		t.Error("peer at baseline must NOT trigger refresh")
+	}
+
+	// Peer B advanced → predicate fires, refresh required.
+	peers["B"] = listAt(baselineB + 1)
+	if !sampler.isStale(meta, peers["A"], peers, 0) {
+		t.Error("peer past baseline MUST trigger refresh")
+	}
+
+	// Peer absent from batch context: predicate can't see B → no refresh.
+	// Caller is responsible for including B in BatchList if they want
+	// this dependency evaluated.
+	peers = map[string]*ListResult{"A": listAt(100)}
+	if sampler.isStale(meta, peers["A"], peers, 0) {
+		t.Error("absent peer must not trigger refresh (predicate sees nil)")
 	}
 }
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -7,15 +7,30 @@ import (
 	"github.com/hkloudou/lake/v3/internal/index"
 )
 
-// AllSnaps returns the latest snap metadata for every catalog in this
-// deployment in a single Redis HGETALL on "<prefix>:s". Backup
-// tooling can feed each (catalog, info.StopTsSeq) into
-// Storage.MakeSnapKey to enumerate every OSS snap key without a LIST.
+// AllSnaps collects every catalog's snap metadata into a map (HSCAN under
+// the hood; no Redis op blocks the server's main thread for more than a
+// few hundred fields at a time). Backup tooling can feed each (catalog,
+// info.StopTsSeq) into Storage.MakeSnapKey to enumerate every OSS snap
+// key without a LIST.
+//
+// For very large fleets prefer IterateSnaps so the full map is never
+// materialised in memory.
 func (c *Client) AllSnaps(ctx context.Context) (map[string]SnapInfo, error) {
 	if err := c.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 	return c.reader.AllSnaps(ctx)
+}
+
+// IterateSnaps streams every catalog's snap to fn — the scalable form of
+// AllSnaps. Stops early when fn returns false; honours ctx cancellation.
+// See (*index.Reader).IterateSnaps for the concurrent-modification
+// semantics inherited from HSCAN.
+func (c *Client) IterateSnaps(ctx context.Context, fn func(catalog string, snap SnapInfo) bool) error {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return err
+	}
+	return c.reader.IterateSnaps(ctx, fn)
 }
 
 // saveSnapshot writes snap bytes to storage and upserts the Redis hash


### PR DESCRIPTION
## Summary

Three independent Sampler / snap improvements, split into one commit each
plus a docs commit. All three were called out in the discussion thread
that produced #2 as work the Sampler refactor enabled but did not finish.

| # | Commit | What |
|---|--------|------|
| 1 | `829f4ce` `feat(sample)!: route the memo hash to an optional dedicated Redis` | New `WithSampleCacheRedis` / `WithSampleCacheURL` options. Sample now reads/writes through `c.sampleRdb` which defaults to the authoritative `rdb`. |
| 2 | `3c07982` `feat(sample)!: wire WithShouldRefresh to cross-catalog peer versions` | Predicate signature gains a `peers map[string]*ListResult` arg — the batch-context lists already in hand (singleton for `Sample`). |
| 3 | `4d6bdc7` `perf(snap): HSCAN AllSnaps and add streaming IterateSnaps` | `AllSnaps` now walks via HSCAN (page 500) and is built on a new public `IterateSnaps(ctx, fn)` streaming primitive. |
| — | `96f6fb5` `docs: README updates for sample cache tier, peer-aware predicate, IterateSnaps` | All three changes reflected in the README. |

## Why each

**1. Cache-tier separation.** README already calls Sample a *cache*; the
implementation pinned it to the authoritative Redis anyway. Splitting it
narrows the "must-not-lose" Redis surface to a small metadata working set
(snap, delta, seqid) and lets the cache tier scale independently. The
existing degradation paths — read-fail recomputes, write-fail returns the
computed value best-effort — already work across two instances; this change
just lets you point at two instances.

**2. Peer versions in the predicate.** The Sampler v1 docs already said
"cross-catalog dependencies should compare versions already in hand", but
the predicate had no way to see other catalogs' versions. The new third
argument is exactly those "versions already in hand": `BatchList`'s lists
map for `Batch`, a singleton for `Sample`. The no-I/O contract is
preserved (you can only see what BatchList already fetched), so a missing
peer means "not requested in this BatchList" rather than "go fetch it now".
T carries the baseline (e.g. `BSeenAt float64`) — Sampler doesn't track
dep versions itself, which would either constrain T or force a richer
SampleMeta schema with no general fit.

**3. HSCAN AllSnaps.** This was the one "real latency landmine" I called
out in the snap-layout discussion. `HGETALL` on `<prefix>:s` is O(N) on
the Redis main thread, and the snap hash grows linearly with catalog
count — the deployment most likely to call `AllSnaps` (backup tooling on
a big fleet) is also the one most likely to stall every other client on
that op. HSCAN with a 500-field page bounds per-op work; total bytes
moved are identical. `AllSnaps` keeps its signature for small fleets, and
the new `IterateSnaps` lets large fleets back up without ever
materialising the full map.

## ⚠️ BREAKING (v3 alpha, "随便改" stance)

- **`WithShouldRefresh`** signature gained a third arg (`peers
  map[string]*ListResult`). Existing predicates need a one-arg-add fix.
  No silent behavioural change for predicates that ignore peers.

Nothing else is wire-breaking. Default `sampleRdb = rdb` means callers
who omit `WithSampleCache*` see identical behaviour to before. HSCAN /
HGETALL produce the same final map for `AllSnaps`.

## Verification

- `go build`, `go vet` clean.
- `go test -race -count=1 . ./internal/index` passes.
- New tests:
  - `TestSamplerCrossCatalogRefresh` — peer at baseline → no refresh;
    peer past baseline → refresh; peer absent → no refresh.
  - `TestIterateSnapsEarlyStop` — 50 seeded catalogs, request stop after
    3, callback ran exactly 3 times.
- Existing `TestSamplerIsStale` ported to the 4-arg signature; behaviour
  matrix unchanged.
- `TestAllSnapsBatchBackup` still passes (now exercises the HSCAN path).

## Test plan

- [ ] Local Redis: bring up a second instance, set `WithSampleCacheURL`
      to it, run `Sampler.Sample` / `Sampler.Batch`, confirm the memo
      hash appears on the cache tier and not on the authoritative
      instance.
- [ ] Cache-tier outage drill: stop the cache Redis mid-run, confirm
      `Sample` recomputes and writes are skipped (SampleCacheError
      events fire); restart, confirm cache repopulates on next call.
- [ ] Cross-catalog refresh: implement a small `Report{BSeenAt}` style
      type, verify `Batch({A, B})` triggers a recompute of A when B
      advances past A's recorded `BSeenAt`.
- [ ] `IterateSnaps` against a hash with thousands of entries —
      observe `MONITOR` shows multiple HSCAN ops, none holding the main
      thread.

https://claude.ai/code/session_01Qppu5sH52TbJoWzp3wPE1J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qppu5sH52TbJoWzp3wPE1J)_