### PR TITLE
Harden WriteNotify validation and read helper safety

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -3,6 +3,7 @@ package lake
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/tidwall/gjson"
@@ -10,11 +11,17 @@ import (
 
 // ReadBytes returns the merged document as raw bytes.
 func ReadBytes(ctx context.Context, list *ListResult) ([]byte, error) {
+	if list == nil || list.client == nil {
+		return nil, errors.New("lake: Read requires a ListResult from List/BatchList")
+	}
 	return list.client.readData(ctx, list)
 }
 
 // ReadString returns the merged document as a JSON string.
 func ReadString(ctx context.Context, list *ListResult) (string, error) {
+	if list == nil || list.client == nil {
+		return "", errors.New("lake: Read requires a ListResult from List/BatchList")
+	}
 	data, err := list.client.readData(ctx, list)
 	if err != nil {
 		return "", err
@@ -24,6 +31,9 @@ func ReadString(ctx context.Context, list *ListResult) (string, error) {
 
 // ReadMap returns the merged document parsed as map[string]any.
 func ReadMap(ctx context.Context, list *ListResult) (map[string]any, error) {
+	if list == nil || list.client == nil {
+		return nil, errors.New("lake: Read requires a ListResult from List/BatchList")
+	}
 	data, err := list.client.readData(ctx, list)
 	if err != nil {
 		return nil, err
@@ -40,6 +50,9 @@ func ReadMap(ctx context.Context, list *ListResult) (map[string]any, error) {
 // Special-cased: T == []byte / string / gjson.Result skip JSON unmarshal
 // and wrap the raw bytes directly.
 func Read[T any](ctx context.Context, list *ListResult) (*T, error) {
+	if list == nil || list.client == nil {
+		return nil, errors.New("lake: Read requires a ListResult from List/BatchList")
+	}
 	data, err := list.client.readData(ctx, list)
 	if err != nil {
 		return nil, err

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,7 +1,9 @@
 package lake
 
 import (
+	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -114,5 +116,22 @@ func TestParseJSON_NoSilentNilNil(t *testing.T) {
 	out, err := parseJSON[gjson.Result]([]byte(`{}`))
 	if err == nil && out == nil {
 		t.Fatal("(nil, nil) is not an acceptable parseJSON return")
+	}
+}
+
+func TestReadHelpers_RejectNilList(t *testing.T) {
+	ctx := context.Background()
+
+	if _, err := ReadBytes(ctx, nil); err == nil || !strings.Contains(err.Error(), "requires a ListResult") {
+		t.Fatalf("ReadBytes(nil) err = %v, want list requirement error", err)
+	}
+	if _, err := ReadString(ctx, nil); err == nil || !strings.Contains(err.Error(), "requires a ListResult") {
+		t.Fatalf("ReadString(nil) err = %v, want list requirement error", err)
+	}
+	if _, err := ReadMap(ctx, nil); err == nil || !strings.Contains(err.Error(), "requires a ListResult") {
+		t.Fatalf("ReadMap(nil) err = %v, want list requirement error", err)
+	}
+	if _, err := Read[gjson.Result](ctx, nil); err == nil || !strings.Contains(err.Error(), "requires a ListResult") {
+		t.Fatalf("Read[T](nil) err = %v, want list requirement error", err)
 	}
 }

--- a/storage/cached/cached.go
+++ b/storage/cached/cached.go
@@ -71,6 +71,9 @@ func Wrap(namespace string, base storage.Storage, cache Cache) storage.Storage {
 //	    return nil // deltas: read once before a snapshot absorbs them — uncached
 //	})
 func Resolver(inner storage.Resolver, policy func(kind storage.Kind, provider, bucket string) Cache) storage.Resolver {
+	if policy == nil {
+		return inner
+	}
 	return func(kind storage.Kind, provider, bucket string) (storage.Storage, error) {
 		base, err := inner(kind, provider, bucket)
 		if err != nil {

--- a/storage/cached/cached_test.go
+++ b/storage/cached/cached_test.go
@@ -144,3 +144,16 @@ func TestResolver_PolicyRoutesCache(t *testing.T) {
 		t.Fatalf("cached bucket should be wrapped, got bare base %T", wrapped)
 	}
 }
+
+func TestResolver_NilPolicyReturnsInner(t *testing.T) {
+	inner := func(_ storage.Kind, _, _ string) (storage.Storage, error) { return newCountingStore(), nil }
+	resolve := Resolver(inner, nil)
+
+	got, err := resolve(storage.Snap, "oss", "bucket")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if _, ok := got.(*countingStore); !ok {
+		t.Fatalf("nil policy should keep inner storage unchanged, got %T", got)
+	}
+}

--- a/write.go
+++ b/write.go
@@ -105,6 +105,9 @@ func (c *Client) WriteBegin(ctx context.Context, req WriteBeginRequest, opts ...
 	for _, opt := range opts {
 		opt(o)
 	}
+	if o.ttl <= 0 {
+		o.ttl = defaultUploadTTL
+	}
 
 	uuid, err := newUUID()
 	if err != nil {
@@ -161,8 +164,14 @@ func (c *Client) WriteNotify(ctx context.Context, h *WriteHandle) error {
 	if err := utils.ValidateFieldPath(h.Path); err != nil {
 		return err
 	}
+	if h.MergeType < MergeTypeReplace || h.MergeType > MergeTypeRFC7396 {
+		return fmt.Errorf("invalid mergeType: %d", h.MergeType)
+	}
 	if h.URI == "" {
 		return errors.New("empty URI in handle")
+	}
+	if _, _, _, err := objkey.ParseURI(h.URI); err != nil {
+		return err
 	}
 	_, _, err := c.writer.Notify(ctx, h.Catalog, h.Path, h.MergeType, h.URI)
 	return err

--- a/write_validation_test.go
+++ b/write_validation_test.go
@@ -1,0 +1,70 @@
+package lake
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hkloudou/lake/v3/storage"
+	"github.com/hkloudou/lake/v3/storage/mem"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestWriteNotify_RejectsInvalidMergeTypeBeforeRedis(t *testing.T) {
+	c := newDeadClient(t)
+	err := c.WriteNotify(context.Background(), &WriteHandle{
+		Catalog:   "users",
+		Path:      "/",
+		MergeType: MergeTypeUnknown,
+		URI:       "mem://data/object.dat",
+	})
+	if err == nil {
+		t.Fatal("expected invalid mergeType error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid mergeType") {
+		t.Fatalf("expected invalid mergeType error, got %v", err)
+	}
+}
+
+func TestWriteNotify_RejectsMalformedURIBeforeRedis(t *testing.T) {
+	c := newDeadClient(t)
+	err := c.WriteNotify(context.Background(), &WriteHandle{
+		Catalog:   "users",
+		Path:      "/",
+		MergeType: MergeTypeReplace,
+		URI:       "oops",
+	})
+	if err == nil {
+		t.Fatal("expected invalid storage URI error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid storage URI") {
+		t.Fatalf("expected invalid storage URI error, got %v", err)
+	}
+}
+
+func TestWriteBegin_ZeroTTLUsesDefaultTTL(t *testing.T) {
+	store := mem.New()
+	resolve := func(_ storage.Kind, _, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	rdb := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
+	t.Cleanup(func() { _ = rdb.Close() })
+	c := New("ttltest", rdb, resolve)
+
+	h, err := c.WriteBegin(context.Background(), WriteBeginRequest{
+		Catalog:   "users",
+		Path:      "/",
+		MergeType: MergeTypeReplace,
+		Provider:  "mem",
+		Bucket:    "data",
+	}, WithUploadTTL(0))
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+
+	ttl := h.ExpiresAt - time.Now().Unix()
+	if ttl < 14*60 || ttl > 16*60 {
+		t.Fatalf("ExpiresAt delta = %ds, want about 15m", ttl)
+	}
+}


### PR DESCRIPTION
## Summary
- validate `WriteNotify` merge type and URI format before writing Redis index entries
- align `WriteBegin` TTL handling by normalizing non-positive upload TTL to the package default
- make `ReadBytes`/`ReadString`/`ReadMap`/`Read[T]` return a clear error for nil or invalid `ListResult` instead of panicking
- make `storage/cached.Resolver` nil-safe by returning `inner` unchanged when no policy is provided
- add regression tests for all of the above behaviors

## Validation
- `go test ./...`
- `go test -race ./...`
