### PR TITLE
Fix read and storage edge cases

### DIFF
--- a/internal/merge/replace.go
+++ b/internal/merge/replace.go
@@ -1,6 +1,7 @@
 package merge
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/tidwall/sjson"
@@ -22,6 +23,9 @@ func NewReplaceMerger() *ReplaceMerger {
 func (m *ReplaceMerger) Merge(original, data []byte, field string) ([]byte, error) {
 	// If field is empty, replace entire document
 	if field == "" {
+		if !json.Valid(data) {
+			return nil, fmt.Errorf("invalid JSON for root replace")
+		}
 		return data, nil
 	}
 

--- a/internal/merge/replace_test.go
+++ b/internal/merge/replace_test.go
@@ -94,3 +94,10 @@ func TestReplaceMerger(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceMerger_RejectsInvalidRootJSON(t *testing.T) {
+	merger := NewReplaceMerger()
+	if _, err := merger.Merge([]byte(`{"old":"data"}`), []byte(`not json`), ""); err == nil {
+		t.Fatal("root replace must reject invalid JSON")
+	}
+}

--- a/read.go
+++ b/read.go
@@ -95,23 +95,27 @@ func (c *Client) fillDeltasBody(ctx context.Context, catalog string, deltas []in
 		workers = pending
 	}
 
-	jobs := make(chan *index.DeltaInfo, len(deltas))
-	done := make(chan error, 1)
+	jobs := make(chan *index.DeltaInfo, pending)
+	for i := range deltas {
+		if len(deltas[i].Body) == 0 {
+			jobs <- &deltas[i]
+		}
+	}
+	close(jobs)
+
+	errCh := make(chan error, 1)
 
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		wg.Go(func() {
 			for d := range jobs {
-				if workerCtx.Err() != nil {
+				if err := workerCtx.Err(); err != nil {
 					return
-				}
-				if len(d.Body) > 0 {
-					continue
 				}
 				data, err := c.fetchURI(workerCtx, storage.Delta, catalog, d.URI)
 				if err != nil {
 					select {
-					case done <- fmt.Errorf("load delta %s: %w", d.TsSeq, err):
+					case errCh <- fmt.Errorf("load delta %s: %w", d.TsSeq, err):
 					default:
 					}
 					cancel()
@@ -122,23 +126,15 @@ func (c *Client) fillDeltasBody(ctx context.Context, catalog string, deltas []in
 		})
 	}
 
-	go func() {
-		for i := range deltas {
-			select {
-			case <-workerCtx.Done():
-				return
-			case jobs <- &deltas[i]:
-			}
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return err
 		}
-		close(jobs)
-	}()
-
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	if err := <-done; err != nil {
+	default:
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 	return nil

--- a/read_test.go
+++ b/read_test.go
@@ -1,0 +1,33 @@
+package lake
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hkloudou/lake/v3/internal/index"
+)
+
+func TestFillDeltasBody_CanceledContextDoesNotHang(t *testing.T) {
+	c := newTestClient("127.0.0.1:1")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- c.fillDeltasBody(ctx, "users", []index.DeltaInfo{{
+			TsSeq: index.TimeSeqID{Timestamp: 1700000000, SeqID: 1},
+			URI:   "mem://data/missing.dat",
+		}})
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("fillDeltasBody hung after context cancellation")
+	}
+}

--- a/storage/cached/cached_test.go
+++ b/storage/cached/cached_test.go
@@ -157,3 +157,41 @@ func TestResolver_NilPolicyReturnsInner(t *testing.T) {
 		t.Fatalf("nil policy should keep inner storage unchanged, got %T", got)
 	}
 }
+
+func TestMemoryCache_CopiesValues(t *testing.T) {
+	cache := NewMemoryCache(time.Minute)
+	ctx := context.Background()
+	loaded := []byte("abc")
+
+	got, err := cache.Take(ctx, "ns", "k", func() ([]byte, error) {
+		return loaded, nil
+	})
+	if err != nil {
+		t.Fatalf("Take miss: %v", err)
+	}
+	got[0] = 'x'
+	loaded[1] = 'y'
+
+	got, err = cache.Take(ctx, "ns", "k", func() ([]byte, error) {
+		t.Fatal("cache hit should not invoke loader")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Take hit: %v", err)
+	}
+	if string(got) != "abc" {
+		t.Fatalf("cached value was mutated through caller-owned slice: got %q", got)
+	}
+	got[2] = 'z'
+
+	got, err = cache.Take(ctx, "ns", "k", func() ([]byte, error) {
+		t.Fatal("cache hit should not invoke loader")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Take second hit: %v", err)
+	}
+	if string(got) != "abc" {
+		t.Fatalf("cache hit returned internal mutable slice: got %q", got)
+	}
+}

--- a/storage/cached/memory.go
+++ b/storage/cached/memory.go
@@ -39,7 +39,7 @@ func (c *MemoryCache) Take(ctx context.Context, namespace, key string, loader fu
 		e, ok := c.data[cacheKey]
 		c.mu.RUnlock()
 		if ok && time.Now().Before(e.expireTime) {
-			return e.value, nil
+			return append([]byte(nil), e.value...), nil
 		}
 		data, err := loader()
 		if err != nil {
@@ -57,8 +57,9 @@ func (c *MemoryCache) Set(_ context.Context, namespace, key string, data []byte)
 }
 
 func (c *MemoryCache) store(cacheKey string, data []byte) {
+	cp := append([]byte(nil), data...)
 	c.mu.Lock()
-	c.data[cacheKey] = cacheEntry{value: data, expireTime: time.Now().Add(c.ttl)}
+	c.data[cacheKey] = cacheEntry{value: cp, expireTime: time.Now().Add(c.ttl)}
 	c.mu.Unlock()
 }
 

--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -29,15 +29,35 @@ func New(basePath string) (*FS, error) {
 }
 
 // Bucket returns a bucket-scoped Storage (bucket = sub-directory).
-func (f *FS) Bucket(name string) storage.Storage { return &view{root: filepath.Join(f.base, name)} }
+func (f *FS) Bucket(name string) storage.Storage {
+	root, err := f.bucketRoot(name)
+	return &view{root: root, err: err}
+}
 
-type view struct{ root string }
+func (f *FS) bucketRoot(name string) (string, error) {
+	if name == "" || name == "." || name == ".." || filepath.IsAbs(name) || strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("file: invalid bucket %q", name)
+	}
+	root := filepath.Join(f.base, name)
+	if root != f.base && !strings.HasPrefix(root, f.base+string(filepath.Separator)) {
+		return "", fmt.Errorf("file: bucket %q escapes base", name)
+	}
+	return root, nil
+}
+
+type view struct {
+	root string
+	err  error
+}
 
 // full resolves path under the bucket root and rejects anything that escapes it
 // (e.g. "..", or an absolute path that cleans out of root). Defence in depth:
 // Lake's own object paths never contain "..", but a storage backend must not
 // trust the path it is handed.
 func (v *view) full(path string) (string, error) {
+	if v.err != nil {
+		return "", v.err
+	}
 	full := filepath.Join(v.root, filepath.FromSlash(path))
 	if full != v.root && !strings.HasPrefix(full, v.root+string(filepath.Separator)) {
 		return "", fmt.Errorf("file: path %q escapes bucket root", path)

--- a/storage/file/file_test.go
+++ b/storage/file/file_test.go
@@ -54,3 +54,27 @@ func TestFile_RejectsTraversal(t *testing.T) {
 		t.Fatalf("canary was modified through traversal: %q", data)
 	}
 }
+
+func TestFile_RejectsEscapingBucket(t *testing.T) {
+	base := t.TempDir()
+	canary := filepath.Join(base, "secret.txt")
+	if err := os.WriteFile(canary, []byte("top secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := New(filepath.Join(base, "store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := fs.Bucket("..")
+	ctx := context.Background()
+
+	if _, err := b.Get(ctx, "users", "secret.txt"); err == nil {
+		t.Fatal("Get with escaping bucket should be rejected")
+	}
+	if err := b.Put(ctx, "users", "secret.txt", []byte("pwned")); err == nil {
+		t.Fatal("Put with escaping bucket should be rejected")
+	}
+	if data, _ := os.ReadFile(canary); string(data) != "top secret" {
+		t.Fatalf("canary was modified through escaping bucket: %q", data)
+	}
+}


### PR DESCRIPTION
## Summary
- validate root Replace payloads before accepting them as complete JSON documents
- make delta body loading return promptly on context cancellation
- defensively copy MemoryCache byte slices on store and hit
- reject file storage bucket names that escape the configured base path

## Tests
- go test ./...
- go test -race ./...
- go vet ./...