### PR TITLE
fix: harden write/read/snapshot paths found in code audit

### DIFF
--- a/internal/index/reader_snap_hash_test.go
+++ b/internal/index/reader_snap_hash_test.go
@@ -166,20 +166,35 @@ func TestSnapHashMonotonic(t *testing.T) {
 		t.Fatalf("equal-stop AddSnap replaced the entry: uri=%q", got.URI)
 	}
 
-	// An undecodable stored value must not wedge the catalog: AddSnap
-	// treats it as absent and overwrites (self-heal).
-	if err := rdb.HSet(ctx, r.MakeSnapsHashKey(), "users", "not-json").Err(); err != nil {
-		t.Fatalf("HSet corrupt: %v", err)
-	}
-	if err := w.AddSnap(ctx, "users", older, "oss://b/"+older.String()+".snap"); err != nil {
-		t.Fatalf("AddSnap over corrupt: %v", err)
-	}
-	got, err = r.GetLatestSnap(ctx, "users")
-	if err != nil {
-		t.Fatalf("GetLatestSnap after heal: %v", err)
-	}
-	if got.StopTsSeq != older {
-		t.Fatalf("corrupt entry not healed: got stop=%v, want %v", got.StopTsSeq, older)
+	// A stored value the Go reader rejects must not wedge the catalog: AddSnap
+	// treats it as absent and overwrites (self-heal) — even at an older stop,
+	// and even when the corrupt value carries a huge tsSeq score. The keep
+	// branch in Lua must therefore mirror DecodeSnapValue exactly; these are
+	// the shapes that score high in a laxer decoder but fail the Go one.
+	for _, corrupt := range []string{
+		"not-json",
+		`["9999999999_1"]`,                 // missing uri
+		`["9999999999_1",""]`,              // empty uri
+		`["9999999999_1",42]`,              // non-string uri
+		`["99999999999999_1","oss://x"]`,   // ts past the year-3000 cap
+		`["09999999999_1","oss://x"]`,      // leading-zero ts
+		`["9999999999_0","oss://x"]`,       // seq 0 outside 1..999999
+		`["9999999999_011","oss://x"]`,     // leading-zero seq
+		`["9999999999_1000000","oss://x"]`, // seq past 999999
+	} {
+		if err := rdb.HSet(ctx, r.MakeSnapsHashKey(), "users", corrupt).Err(); err != nil {
+			t.Fatalf("HSet corrupt %q: %v", corrupt, err)
+		}
+		if err := w.AddSnap(ctx, "users", older, "oss://b/"+older.String()+".snap"); err != nil {
+			t.Fatalf("AddSnap over corrupt %q: %v", corrupt, err)
+		}
+		got, err = r.GetLatestSnap(ctx, "users")
+		if err != nil {
+			t.Fatalf("GetLatestSnap after healing %q: %v", corrupt, err)
+		}
+		if got.StopTsSeq != older {
+			t.Fatalf("corrupt entry %q not healed: got stop=%v, want %v", corrupt, got.StopTsSeq, older)
+		}
 	}
 }
 

--- a/internal/index/reader_snap_hash_test.go
+++ b/internal/index/reader_snap_hash_test.go
@@ -90,8 +90,8 @@ func TestSnapHashRoundTrip(t *testing.T) {
 	}
 }
 
-// TestSnapHashOverwrite confirms the V3 contract: each AddSnap on a
-// catalog overwrites its previous entry.
+// TestSnapHashOverwrite confirms the V3 contract: an AddSnap with a newer
+// stop overwrites the catalog's previous entry (still one field per catalog).
 func TestSnapHashOverwrite(t *testing.T) {
 	rdb, prefix := indexTestRedis(t)
 	w := NewWriter(rdb)
@@ -124,6 +124,62 @@ func TestSnapHashOverwrite(t *testing.T) {
 	}
 	if cnt != 1 {
 		t.Fatalf("HLen: got %d, want 1 (one catalog, one field)", cnt)
+	}
+}
+
+// TestSnapHashMonotonic pins AddSnap's anti-regression guard: snapshot saves
+// are async and may race across processes, so a save computed at an OLDER
+// stop that lands late must NOT regress the snap pointer. Equal stops keep
+// the stored entry too (first writer wins). Run against real Redis because
+// the guard lives in Lua.
+func TestSnapHashMonotonic(t *testing.T) {
+	rdb, prefix := indexTestRedis(t)
+	w := NewWriter(rdb)
+	r := NewReader(rdb)
+	w.SetPrefix(prefix)
+	r.SetPrefix(prefix)
+
+	ctx := context.Background()
+	older := TimeSeqID{Timestamp: 1700000100, SeqID: 500}
+	newer := TimeSeqID{Timestamp: 1700000200, SeqID: 1}
+
+	if err := w.AddSnap(ctx, "users", newer, "oss://b/"+newer.String()+".snap"); err != nil {
+		t.Fatalf("AddSnap newer: %v", err)
+	}
+	// A late save at an older stop is silently dropped.
+	if err := w.AddSnap(ctx, "users", older, "oss://b/"+older.String()+".snap"); err != nil {
+		t.Fatalf("AddSnap older: %v", err)
+	}
+	// Same stop, different uri: stored entry wins.
+	if err := w.AddSnap(ctx, "users", newer, "oss://elsewhere/"+newer.String()+".snap"); err != nil {
+		t.Fatalf("AddSnap equal: %v", err)
+	}
+
+	got, err := r.GetLatestSnap(ctx, "users")
+	if err != nil {
+		t.Fatalf("GetLatestSnap: %v", err)
+	}
+	if got.StopTsSeq != newer {
+		t.Fatalf("snap pointer regressed: got stop=%v, want %v", got.StopTsSeq, newer)
+	}
+	if got.URI != "oss://b/"+newer.String()+".snap" {
+		t.Fatalf("equal-stop AddSnap replaced the entry: uri=%q", got.URI)
+	}
+
+	// An undecodable stored value must not wedge the catalog: AddSnap
+	// treats it as absent and overwrites (self-heal).
+	if err := rdb.HSet(ctx, r.MakeSnapsHashKey(), "users", "not-json").Err(); err != nil {
+		t.Fatalf("HSet corrupt: %v", err)
+	}
+	if err := w.AddSnap(ctx, "users", older, "oss://b/"+older.String()+".snap"); err != nil {
+		t.Fatalf("AddSnap over corrupt: %v", err)
+	}
+	got, err = r.GetLatestSnap(ctx, "users")
+	if err != nil {
+		t.Fatalf("GetLatestSnap after heal: %v", err)
+	}
+	if got.StopTsSeq != older {
+		t.Fatalf("corrupt entry not healed: got stop=%v, want %v", got.StopTsSeq, older)
 	}
 }
 

--- a/internal/index/writer_snap.go
+++ b/internal/index/writer_snap.go
@@ -24,13 +24,23 @@ func NewWriter(rdb *redis.Client) *Writer {
 // wasteful — every read replays more deltas until it heals). A stored value
 // that fails to decode is treated as absent and overwritten (self-heal).
 // Returns 1 when the entry was written, 0 when the stored snap was kept.
+//
+// The keep branch must accept only values DecodeSnapValue (encoding.go) +
+// ParseTimeSeqID (timeseqid.go) accept — keeping anything the Go reader
+// rejects would wedge the catalog (GetLatestSnap fails, and no later AddSnap
+// could overwrite). Hence the full mirror of the Go rules: a 2-string
+// [tsSeq, uri] with non-empty uri; ts with no leading zero, ≤ year-3000 cap;
+// seq 1..999999 with no leading zero. (The "0_0" sentinel deliberately fails
+// the match: it scores 0, so any real stop would overwrite it anyway.)
 const addSnapScript = `
 local cur = redis.call("HGET", KEYS[1], ARGV[1])
 if cur then
   local ok, arr = pcall(cjson.decode, cur)
-  if ok and type(arr) == "table" and type(arr[1]) == "string" then
-    local ts, seq = string.match(arr[1], "^(%d+)_(%d+)$")
-    if ts and tonumber(ts) + tonumber(seq) / 1000000.0 >= tonumber(ARGV[3]) then
+  if ok and type(arr) == "table" and type(arr[1]) == "string"
+        and type(arr[2]) == "string" and arr[2] ~= "" then
+    local ts, seq = string.match(arr[1], "^([1-9]%d*)_([1-9]%d?%d?%d?%d?%d?)$")
+    if ts and tonumber(ts) <= 32503680000
+          and tonumber(ts) + tonumber(seq) / 1000000.0 >= tonumber(ARGV[3]) then
       return 0
     end
   end

--- a/internal/index/writer_snap.go
+++ b/internal/index/writer_snap.go
@@ -17,13 +17,39 @@ func NewWriter(rdb *redis.Client) *Writer {
 	return &Writer{rdb: rdb}
 }
 
-// AddSnap upserts the catalog's snap entry in "<prefix>:s" as [tsSeq, uri].
-// HSet overwrites any prior entry; the previous snap object is left orphan in
-// storage (V3 contract).
+// addSnapScript upserts the catalog's snap entry only when the new stop is
+// strictly newer than the stored one. Snapshot saves are async and may race
+// across processes: without the guard, a slow save computed at an older stop
+// could land after a newer one and regress the snap pointer (correct but
+// wasteful — every read replays more deltas until it heals). A stored value
+// that fails to decode is treated as absent and overwritten (self-heal).
+// Returns 1 when the entry was written, 0 when the stored snap was kept.
+const addSnapScript = `
+local cur = redis.call("HGET", KEYS[1], ARGV[1])
+if cur then
+  local ok, arr = pcall(cjson.decode, cur)
+  if ok and type(arr) == "table" and type(arr[1]) == "string" then
+    local ts, seq = string.match(arr[1], "^(%d+)_(%d+)$")
+    if ts and tonumber(ts) + tonumber(seq) / 1000000.0 >= tonumber(ARGV[3]) then
+      return 0
+    end
+  end
+end
+redis.call("HSET", KEYS[1], ARGV[1], ARGV[2])
+return 1
+`
+
+// AddSnap upserts the catalog's snap entry in "<prefix>:s" as [tsSeq, uri],
+// but only monotonically: an entry at or past stopTsSeq is kept and the call
+// is a silent no-op (the freshly written snap object is left orphan in
+// storage, like any superseded snap — V3 contract).
 func (w *Writer) AddSnap(ctx context.Context, catalog string, stopTsSeq TimeSeqID, uri string) error {
 	val, err := EncodeSnapValue(stopTsSeq, uri)
 	if err != nil {
 		return err
 	}
-	return w.rdb.HSet(ctx, w.MakeSnapsHashKey(), catalog, val).Err()
+	return w.rdb.Eval(ctx, addSnapScript,
+		[]string{w.MakeSnapsHashKey()},
+		catalog, val, stopTsSeq.Score(),
+	).Err()
 }

--- a/read.go
+++ b/read.go
@@ -50,10 +50,14 @@ func (c *Client) readData(ctx context.Context, list *ListResult) ([]byte, error)
 
 	// Async snapshot save: fire-and-forget on a background context so an aborted
 	// Read does not cancel a snapshot that benefits everyone else. Skipped
-	// entirely when no snap target is configured.
+	// entirely when no snap target is configured. The goroutine gets a private
+	// copy: resultData is returned to the caller, who is free to mutate it
+	// while the save is still reading — and a mutated snapshot would poison
+	// every later read of the catalog.
 	if c.snapProvider != "" {
 		if next := list.NextSnap(); next != nil {
-			go c.saveSnapshot(context.Background(), list.catalog, next.StopTsSeq, resultData)
+			snapData := append([]byte(nil), resultData...)
+			go c.saveSnapshot(context.Background(), list.catalog, next.StopTsSeq, snapData)
 		}
 	}
 	return resultData, nil

--- a/sample.go
+++ b/sample.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hkloudou/lake/v3/internal/utils"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -67,11 +68,16 @@ type SamplerOption[T any] func(*Sampler[T])
 
 // NewSampler builds a reusable Sampler for one indicator. loader computes
 // the sample from a catalog's ListResult on a cache miss. It panics if
-// indicator is empty or loader is nil (programmer error — fail-fast, per
-// package policy).
+// indicator is empty or invalid, or loader is nil (programmer error —
+// fail-fast, per package policy). The indicator is embedded verbatim in the
+// Redis memo key "<prefix>:m:<indicator>", so it follows the same charset
+// rules as catalog names (no ":" "|" "(" ")", ASCII only).
 func NewSampler[T any](indicator string, loader func(*ListResult) (T, error), opts ...SamplerOption[T]) *Sampler[T] {
 	if indicator == "" {
 		panic("lake: NewSampler indicator must be non-empty")
+	}
+	if err := utils.ValidateCatalog(indicator); err != nil {
+		panic(fmt.Sprintf("lake: NewSampler invalid indicator: %v", err))
 	}
 	if loader == nil {
 		panic("lake: NewSampler loader must be non-nil")
@@ -267,7 +273,10 @@ func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, peers map[string
 	if !(meta.Score >= lastUpdated && meta.Score > 0) {
 		return true // data advanced past the cached version (or none) → refresh
 	}
-	if s.maxAge > 0 && now > 0 && meta.UpdatedAt > 0 && now-meta.UpdatedAt >= int64(s.maxAge.Seconds()) {
+	// Compare in time.Duration so a sub-second maxAge keeps its value instead
+	// of truncating to 0 (which would mark every hit stale). The clock itself
+	// still ticks in whole seconds (~5s resolution).
+	if s.maxAge > 0 && now > 0 && meta.UpdatedAt > 0 && time.Duration(now-meta.UpdatedAt)*time.Second >= s.maxAge {
 		return true
 	}
 	if s.shouldRefresh != nil && s.shouldRefresh(meta, list, peers) {

--- a/sample_test.go
+++ b/sample_test.go
@@ -38,6 +38,27 @@ func TestSampleCacheCodec(t *testing.T) {
 	}
 }
 
+// TestNewSamplerValidatesIndicator: the indicator is embedded verbatim in
+// the Redis memo key "<prefix>:m:<indicator>", so NewSampler enforces the
+// catalog charset on it (fail-fast panic, per package policy).
+func TestNewSamplerValidatesIndicator(t *testing.T) {
+	loader := func(*ListResult) (int, error) { return 0, nil }
+
+	for _, ok := range []string{"x", "user-stats", "a/b", "A.B_c"} {
+		NewSampler[int](ok, loader) // must not panic
+	}
+	for _, bad := range []string{"a:b", "a|b", "(paren", "has space", "中文"} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("indicator %q: expected panic, got none", bad)
+				}
+			}()
+			NewSampler[int](bad, loader)
+		}()
+	}
+}
+
 // TestSamplerIsStale locks in the layered staleness contract: the data-
 // version floor is mandatory, while maxAge and shouldRefresh can only ADD
 // refresh triggers — never suppress one the data version requires.
@@ -65,6 +86,16 @@ func TestSamplerIsStale(t *testing.T) {
 	}
 	if !aged.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), noPeers, 1015) {
 		t.Error("past maxAge should be stale")
+	}
+
+	// Sub-second maxAge must not truncate to "always stale": with the clock at
+	// the same second as the compute, the entry is younger than maxAge → fresh.
+	subSec := NewSampler[int]("x", base.loader, WithMaxAge[int](500*time.Millisecond))
+	if subSec.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), noPeers, 1000) {
+		t.Error("sub-second maxAge with zero elapsed must be fresh")
+	}
+	if !subSec.isStale(SampleMeta{Score: 100, UpdatedAt: 1000}, listAt(100), noPeers, 1001) {
+		t.Error("sub-second maxAge past one elapsed second must be stale")
 	}
 
 	// shouldRefresh is additive: true forces a refresh even when fresh...

--- a/snapshot.go
+++ b/snapshot.go
@@ -21,8 +21,10 @@ func (c *Client) IterateSnaps(ctx context.Context, fn func(catalog string, snap 
 }
 
 // saveSnapshot writes snap bytes to the configured snap target and upserts the
-// Redis hash entry (as [tsSeq, uri]). No-op when no snap target is configured.
-// SingleFlight on (catalog, stop) dedupes concurrent saves.
+// Redis hash entry (as [tsSeq, uri]) — monotonically: AddSnap drops the upsert
+// if a newer snap already landed, so racing saves can never regress the
+// pointer. No-op when no snap target is configured. SingleFlight on
+// (catalog, stop) dedupes concurrent saves within this process.
 func (c *Client) saveSnapshot(ctx context.Context, catalog string, stop index.TimeSeqID, data []byte) (string, error) {
 	if c.snapProvider == "" || c.snapBucket == "" {
 		return "", nil

--- a/write.go
+++ b/write.go
@@ -148,6 +148,11 @@ func (c *Client) WriteBegin(ctx context.Context, req WriteBeginRequest, opts ...
 // delta (carrying handle.URI) in Redis. It does NOT touch storage — the body
 // is already at handle.URI from the direct upload.
 //
+// Handles round-trip through clients Lake does not trust, so Notify rebinds
+// the handle to its own catalog: the URI's object path must be exactly the
+// delta path WriteBegin derived for (Catalog, UUID). A tampered handle can
+// therefore never point a catalog's index at another catalog's objects.
+//
 // Notify is NOT idempotent — duplicate calls produce duplicate deltas (each
 // with its own tsSeq, all referencing the same URI). For Replace / RFC7396,
 // applying the same body twice is benign; nevertheless, callers should retry
@@ -167,13 +172,20 @@ func (c *Client) WriteNotify(ctx context.Context, h *WriteHandle) error {
 	if h.MergeType < MergeTypeReplace || h.MergeType > MergeTypeRFC7396 {
 		return fmt.Errorf("invalid mergeType: %d", h.MergeType)
 	}
+	if !isUUIDHex(h.UUID) {
+		return fmt.Errorf("invalid uuid in handle: %q", h.UUID)
+	}
 	if h.URI == "" {
 		return errors.New("empty URI in handle")
 	}
-	if _, _, _, err := objkey.ParseURI(h.URI); err != nil {
+	_, _, path, err := objkey.ParseURI(h.URI)
+	if err != nil {
 		return err
 	}
-	_, _, err := c.writer.Notify(ctx, h.Catalog, h.Path, h.MergeType, h.URI)
+	if want := objkey.DeltaPath(h.Catalog, h.UUID); path != want {
+		return fmt.Errorf("handle URI path %q does not match catalog/uuid (want %q)", path, want)
+	}
+	_, _, err = c.writer.Notify(ctx, h.Catalog, h.Path, h.MergeType, h.URI)
 	return err
 }
 
@@ -186,4 +198,20 @@ func newUUID() (string, error) {
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
 	return hex.EncodeToString(b[:]), nil
+}
+
+// isUUIDHex reports whether s is exactly the form newUUID emits: 32 lowercase
+// hex chars. WriteNotify uses it to keep a client-supplied UUID from smuggling
+// path segments into the recomputed delta path.
+func isUUIDHex(s string) bool {
+	if len(s) != 32 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }

--- a/write_read_test.go
+++ b/write_read_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hkloudou/lake/v3/internal/objkey"
 	"github.com/hkloudou/lake/v3/storage"
 	"github.com/hkloudou/lake/v3/storage/mem"
 	"github.com/tidwall/gjson"
@@ -80,5 +81,68 @@ func TestWriteReadRoundTrip_Redis(t *testing.T) {
 	// before cleanup (a fire-and-forget goroutine otherwise writes after Cleanup).
 	if !waitFor(func() bool { s, _ := c.reader.GetLatestSnap(ctx, "users"); return s != nil }) {
 		t.Fatal("snapshot was not indexed within timeout")
+	}
+}
+
+// TestReadBytesMutationDoesNotCorruptSnapshot pins the isolation between the
+// bytes ReadBytes hands the caller and the bytes the async snapshot save
+// persists: the caller owns its slice and may mutate it immediately, and the
+// snapshot must still capture the original merged document. (A shared slice
+// here once meant a caller mutation could persist a corrupt snapshot, which
+// then poisoned every later read of the catalog.)
+func TestReadBytesMutationDoesNotCorruptSnapshot(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve, WithSnapTarget("mem", "snaps"))
+
+	ctx := context.Background()
+	h, err := c.WriteBegin(ctx, WriteBeginRequest{
+		Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+	})
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+	const doc = `{"name":"Alice"}`
+	if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(doc)); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := c.WriteNotify(ctx, h); err != nil {
+		t.Fatalf("WriteNotify: %v", err)
+	}
+
+	list := c.List(ctx, "users")
+	if list.Err != nil {
+		t.Fatalf("List: %v", list.Err)
+	}
+	got, err := ReadBytes(ctx, list)
+	if err != nil {
+		t.Fatalf("ReadBytes: %v", err)
+	}
+	// Caller mutates its result right away, while the snapshot save may still
+	// be running in the background.
+	for i := range got {
+		got[i] = 'X'
+	}
+
+	var snap *SnapInfo
+	if !waitFor(func() bool { snap, _ = c.reader.GetLatestSnap(ctx, "users"); return snap != nil }) {
+		t.Fatal("snapshot was not indexed within timeout")
+	}
+	_, _, path, err := objkey.ParseURI(snap.URI)
+	if err != nil {
+		t.Fatalf("parse snap URI %q: %v", snap.URI, err)
+	}
+	data, err := store.Bucket("snaps").Get(ctx, "users", path)
+	if err != nil {
+		t.Fatalf("fetch snap object: %v", err)
+	}
+	if string(data) != doc {
+		t.Fatalf("snapshot content corrupted by caller mutation: got %q, want %q", data, doc)
 	}
 }

--- a/write_validation_test.go
+++ b/write_validation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hkloudou/lake/v3/internal/objkey"
 	"github.com/hkloudou/lake/v3/storage"
 	"github.com/hkloudou/lake/v3/storage/mem"
 	"github.com/redis/go-redis/v9"
@@ -27,12 +28,17 @@ func TestWriteNotify_RejectsInvalidMergeTypeBeforeRedis(t *testing.T) {
 	}
 }
 
+// testUUID is a well-formed (32 lowercase hex) handle UUID for tests that
+// must get past the UUID check to reach a later validation step.
+const testUUID = "0123456789abcdef0123456789abcdef"
+
 func TestWriteNotify_RejectsMalformedURIBeforeRedis(t *testing.T) {
 	c := newDeadClient(t)
 	err := c.WriteNotify(context.Background(), &WriteHandle{
 		Catalog:   "users",
 		Path:      "/",
 		MergeType: MergeTypeReplace,
+		UUID:      testUUID,
 		URI:       "oops",
 	})
 	if err == nil {
@@ -40,6 +46,50 @@ func TestWriteNotify_RejectsMalformedURIBeforeRedis(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid storage URI") {
 		t.Fatalf("expected invalid storage URI error, got %v", err)
+	}
+}
+
+// TestWriteNotify_RejectsTamperedUUID: a handle whose UUID is not the exact
+// 32-hex form WriteBegin mints is rejected before any Redis call — the UUID
+// participates in the recomputed delta path, so it must not carry path
+// metacharacters.
+func TestWriteNotify_RejectsTamperedUUID(t *testing.T) {
+	c := newDeadClient(t)
+	for _, uuid := range []string{"", "short", strings.Repeat("g", 32), testUUID + "ff", "../" + testUUID[3:]} {
+		err := c.WriteNotify(context.Background(), &WriteHandle{
+			Catalog:   "users",
+			Path:      "/",
+			MergeType: MergeTypeReplace,
+			UUID:      uuid,
+			URI:       "mem://data/whatever.dat",
+		})
+		if err == nil || !strings.Contains(err.Error(), "invalid uuid") {
+			t.Fatalf("uuid %q: expected invalid uuid error, got %v", uuid, err)
+		}
+	}
+}
+
+// TestWriteNotify_RejectsForeignURI: handles round-trip through untrusted
+// clients, so Notify must refuse a URI whose object path is not the delta
+// path derived from this handle's own (catalog, uuid) — otherwise a tampered
+// handle could point catalog A's index at catalog B's objects (or anywhere).
+func TestWriteNotify_RejectsForeignURI(t *testing.T) {
+	c := newDeadClient(t)
+	for _, uri := range []string{
+		"mem://data/" + objkey.DeltaPath("other-catalog", testUUID), // another catalog's object
+		"mem://data/arbitrary/object.dat",                           // free-form path
+		"mem://data/" + objkey.SnapPath("users", "1700000000_1"),    // a snap, not a delta
+	} {
+		err := c.WriteNotify(context.Background(), &WriteHandle{
+			Catalog:   "users",
+			Path:      "/",
+			MergeType: MergeTypeReplace,
+			UUID:      testUUID,
+			URI:       uri,
+		})
+		if err == nil || !strings.Contains(err.Error(), "does not match catalog/uuid") {
+			t.Fatalf("uri %q: expected catalog/uuid mismatch error, got %v", uri, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Four fixes from a full-codebase review (`go vet`, `go test ./...`, and `go test -race` all pass; integration tests ran against a live Redis, including the new Lua guard):

## 1. Snapshot isolation from the caller's bytes (read.go)

`readData` handed the same `[]byte` to both the caller (via `ReadBytes` / `Read[[]byte]`) and the fire-and-forget snapshot save. A caller mutating its result while the save was still reading could persist a corrupted snapshot — which is the merge base for every later read, so the catalog's reads would be permanently poisoned (and a failed read never writes a replacement snap). The goroutine now gets a private copy. Regression test mutates the caller's slice immediately and pins the stored snapshot content.

## 2. WriteNotify rebinds the handle to its own catalog (write.go)

Handles round-trip through untrusted clients by design, but `WriteNotify` only shape-checked the URI — a tampered handle could record a delta pointing at **another catalog's objects** (or any resolvable path). Notify now requires:

- the UUID to be the exact 32-lowercase-hex form `WriteBegin` mints (so it can't smuggle path segments), and
- the URI's object path to equal `objkey.DeltaPath(Catalog, UUID)`.

A delta recorded into catalog X can therefore only ever point into X's own object shard. New rejection tests cover tampered UUIDs, cross-catalog URIs, free-form paths, and snap paths.

## 3. Monotonic AddSnap (internal/index/writer_snap.go)

Snapshot saves are async and race across processes: a slow save computed at an older stop could land after a newer one and regress the snap pointer (correct but wasteful until it healed). `AddSnap` is now a Lua compare-and-set — only a strictly newer stop overwrites; an undecodable stored value is treated as absent and overwritten (self-heal). `TestSnapHashMonotonic` pins all three behaviors against live Redis.

## 4. Sampler fixes (sample.go)

- `WithMaxAge` under 1s truncated to 0 via `int64(d.Seconds())`, turning the cache into "always stale". Comparison is now done in `time.Duration`.
- `NewSampler` validates the indicator with the catalog charset (it is embedded verbatim in the Redis memo key `<prefix>:m:<indicator>`); invalid indicators panic at construction, matching package policy.

https://claude.ai/code/session_01VqJozJxfijWpZpmVW53Xac

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqJozJxfijWpZpmVW53Xac)_