### PR TITLE
feat: explicit Compact API + atomic (snap, deltas) read

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ The index entry is created only at `WriteNotify`, *after* the upload succeeded �
 so a slow or aborted upload never appears in the index, and there is no pending
 state to roll back.
 
-**A read** fetches the snapshot pointer + delta log (2 Redis ops), loads the
-bodies through the resolver, and merges them. With a snapshot target configured a
-fresh snapshot is written back asynchronously, off the read's critical path; wrap
-the resolver in the recommended `storage/cached` decorator and bodies come from
-cache, not a cold fetch.
+**A read** fetches the snapshot pointer + delta log (1 atomic Redis op — a Lua
+script returns both together, so a read can never pair a stale pointer with a
+compacted log), loads the bodies through the resolver, and merges them. With a
+snapshot target configured a fresh snapshot is written back asynchronously, off
+the read's critical path; wrap the resolver in the recommended `storage/cached`
+decorator and bodies come from cache, not a cold fetch.
 
 ## 🚀 Quick Start
 
@@ -564,12 +565,18 @@ A snapshot is an optimization. If the async save fails, the next read
 regenerates it. Reads never wait for a snapshot to be persisted. With no
 `WithSnapTarget`, snapshotting is simply off — reads replay all deltas.
 
-### No background compaction (yet)
+### Compaction is explicit — and index-only
 
-There is no `ClearHistory` and no reaper in v3-alpha: delta zsets and their
-objects accumulate. Reads stay correct and fast (they start from the latest
-snapshot and skip everything below it), but storage grows. Compaction will
-return as explicit caller-side tooling.
+There is no background reaper. `Compact(ctx, catalog)` trims the delta zset up
+to the current snapshot (the entries a read can never fetch again) and returns
+how many it removed; sweep catalogs on your own schedule, e.g. via
+`IterateSnaps`. It is safe to run at any time from any process: reads observe
+the snap pointer and the delta log atomically, and the pointer is monotonic,
+so compaction can never remove a delta a concurrent read still needs.
+
+Compact touches Redis only. Delta *objects* in storage are untouched — they
+remain portable history, and object deletion belongs to bucket lifecycle
+rules, not Lake. A catalog with no snapshot is left intact.
 
 ## 🔄 Migrating from v2 to v3
 
@@ -585,7 +592,7 @@ v3 is **not** wire-compatible with v2. The headline changes:
   `[tsSeq, uri]` — old members/snaps don't decode; flush and repopulate.
 - **RFC 6902 removed**: only `MergeTypeReplace` (1) and `MergeTypeRFC7396` (2)
   remain.
-- **`ClearHistory` removed** (compaction deferred). **`AllSnaps` removed** — use
+- **`ClearHistory` removed** — use the explicit `Compact`. **`AllSnaps` removed** — use
   `IterateSnaps`. **File API**, **`WriteRequest.Meta`**, and **`MotionSample`**
   removed (use `NewSampler[T]`).
 - **Snapshots auto-generate** to `WithSnapTarget`; omit it to disable.

--- a/compact.go
+++ b/compact.go
@@ -1,0 +1,38 @@
+package lake
+
+import (
+	"context"
+
+	"github.com/hkloudou/lake/v3/internal/utils"
+)
+
+// Compact removes the index entries of every delta the catalog's current
+// snapshot has already absorbed (delta score ≤ snap stop, inclusive — the
+// read path only ever fetches deltas strictly after the stop). It returns
+// the number of entries removed.
+//
+// Scope: Redis only. The delta OBJECTS in storage are untouched — they
+// remain fetchable history, and object deletion belongs to bucket lifecycle
+// rules, not Lake. Compacting changes no read result, only reclaims index
+// memory.
+//
+// Safe to call at any time, from any process:
+//
+//   - reads observe (snap pointer, deltas after it) atomically in one script,
+//     so a concurrent read either ran before this compaction (and already has
+//     its deltas) or after (and starts from a snap that covers them) — there
+//     is no interleaving that loses the range in between;
+//   - the snap pointer is monotonic (AddSnap), so the bound this call trims
+//     to can never move backwards past a delta some reader still needs.
+//
+// A catalog with no snapshot (or an undecodable snap entry) is left intact
+// and returns (0, nil). Compaction is explicit by design — there is no
+// background reaper; sweep catalogs on your own schedule, e.g. via
+// IterateSnaps.
+func (c *Client) Compact(ctx context.Context, catalog string) (int64, error) {
+	c.emitEvent(catalog, "Compact", nil)
+	if err := utils.ValidateCatalog(catalog); err != nil {
+		return 0, err
+	}
+	return c.writer.CompactDeltas(ctx, catalog)
+}

--- a/compact_test.go
+++ b/compact_test.go
@@ -1,0 +1,116 @@
+package lake
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hkloudou/lake/v3/storage"
+	"github.com/hkloudou/lake/v3/storage/mem"
+)
+
+func TestCompact_ValidatesCatalogBeforeRedis(t *testing.T) {
+	c := newDeadClient(t)
+	if _, err := c.Compact(context.Background(), "bad|name"); err == nil || !strings.Contains(err.Error(), "invalid catalog") {
+		t.Fatalf("expected invalid catalog error, got %v", err)
+	}
+}
+
+// TestCompactRoundTrip_Redis is the end-to-end contract: compacting after a
+// snapshot changes NO read result — it only empties the absorbed part of the
+// delta index — and subsequent writes/reads keep working on top of the
+// compacted catalog.
+func TestCompactRoundTrip_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve, WithSnapTarget("mem", "snaps"))
+
+	ctx := context.Background()
+	write := func(path string, mt MergeType, body string) {
+		t.Helper()
+		h, err := c.WriteBegin(ctx, WriteBeginRequest{
+			Catalog: "users", Path: path, MergeType: mt, Provider: "mem", Bucket: "data",
+		})
+		if err != nil {
+			t.Fatalf("WriteBegin(%s): %v", path, err)
+		}
+		if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(body)); err != nil {
+			t.Fatalf("upload: %v", err)
+		}
+		if err := c.WriteNotify(ctx, h); err != nil {
+			t.Fatalf("WriteNotify(%s): %v", path, err)
+		}
+	}
+
+	write("/", MergeTypeReplace, `{"name":"Alice"}`)
+	write("/profile", MergeTypeRFC7396, `{"city":"NYC"}`)
+
+	doc1, err := ReadString(ctx, c.List(ctx, "users"))
+	if err != nil {
+		t.Fatalf("first ReadString: %v", err)
+	}
+	// The read fired an async snapshot save; compaction has nothing to trim
+	// until the snap pointer lands.
+	if !waitFor(func() bool { s, _ := c.reader.GetLatestSnap(ctx, "users"); return s != nil }) {
+		t.Fatal("snapshot was not indexed within timeout")
+	}
+
+	n, err := c.Compact(ctx, "users")
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("Compact removed %d entries, want 2", n)
+	}
+
+	// Snapshot-only read: identical document, zero deltas replayed.
+	list := c.List(ctx, "users")
+	if list.Err != nil {
+		t.Fatalf("List after compact: %v", list.Err)
+	}
+	if list.LatestSnap == nil || len(list.Entries) != 0 {
+		t.Fatalf("after compact: snap=%v entries=%d, want snap + 0 entries", list.LatestSnap, len(list.Entries))
+	}
+	doc2, err := ReadString(ctx, list)
+	if err != nil {
+		t.Fatalf("ReadString after compact: %v", err)
+	}
+	if doc2 != doc1 {
+		t.Fatalf("compaction changed the read result:\n before: %s\n after:  %s", doc1, doc2)
+	}
+
+	// A write after compaction lands past the snap stop, so a compact run
+	// before the next snapshot must not touch it.
+	write("/profile", MergeTypeRFC7396, `{"age":31}`)
+	list = c.List(ctx, "users")
+	if list.Err != nil || len(list.Entries) != 1 {
+		t.Fatalf("List after new write: err=%v entries=%d, want 1", list.Err, len(list.Entries))
+	}
+	if n, err = c.Compact(ctx, "users"); err != nil || n != 0 {
+		t.Fatalf("compact before new snap: removed=%d err=%v, want 0/nil", n, err)
+	}
+	doc3, err := ReadString(ctx, c.List(ctx, "users"))
+	if err != nil {
+		t.Fatalf("ReadString after new write: %v", err)
+	}
+	for _, want := range []string{`"name":"Alice"`, `"city":"NYC"`, `"age":31`} {
+		if !strings.Contains(doc3, want) {
+			t.Fatalf("merged doc missing %s: %s", want, doc3)
+		}
+	}
+	// Drain the async snapshot save triggered by the last read so its Redis
+	// write lands before cleanup.
+	stop3 := list.Entries[0].TsSeq
+	if !waitFor(func() bool {
+		s, _ := c.reader.GetLatestSnap(ctx, "users")
+		return s != nil && s.StopTsSeq == stop3
+	}) {
+		t.Fatal("post-write snapshot was not indexed within timeout")
+	}
+}

--- a/internal/index/compact_test.go
+++ b/internal/index/compact_test.go
@@ -1,0 +1,79 @@
+package index
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCompactDeltas drives the real notify Lua for deltas, then pins the
+// compaction contract against live Redis: nothing is trimmed without a
+// decodable snap pointer; the trim bound is inclusive of the stop; the call
+// is idempotent; entries past the stop survive.
+func TestCompactDeltas(t *testing.T) {
+	rdb, prefix := indexTestRedis(t)
+	w := NewWriter(rdb)
+	r := NewReader(rdb)
+	w.SetPrefix(prefix)
+	r.SetPrefix(prefix)
+
+	ctx := context.Background()
+	const catalog = "users"
+	const uri = "oss://bucket/4f3a/(users/abc.dat"
+
+	// No snap yet → no-op.
+	n, err := w.CompactDeltas(ctx, catalog)
+	if err != nil {
+		t.Fatalf("CompactDeltas (no snap): %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("no-snap compact removed %d entries, want 0", n)
+	}
+
+	var stops []TimeSeqID
+	for i := 0; i < 3; i++ {
+		ts, _, err := w.Notify(ctx, catalog, "/", MergeTypeReplace, uri)
+		if err != nil {
+			t.Fatalf("Notify #%d: %v", i, err)
+		}
+		stops = append(stops, ts)
+	}
+
+	// A snap pointer the Go reader rejects must never authorize a trim, no
+	// matter how high it scores.
+	if err := rdb.HSet(ctx, w.MakeSnapsHashKey(), catalog, `["9999999999_1",""]`).Err(); err != nil {
+		t.Fatalf("HSet corrupt snap: %v", err)
+	}
+	if n, err = w.CompactDeltas(ctx, catalog); err != nil || n != 0 {
+		t.Fatalf("corrupt-snap compact: removed=%d err=%v, want 0/nil", n, err)
+	}
+	if card := rdb.ZCard(ctx, w.MakeDeltaZsetKey(catalog)).Val(); card != 3 {
+		t.Fatalf("zset after corrupt-snap compact: %d entries, want 3", card)
+	}
+
+	// Snap at the 2nd delta absorbs the first two (bound is inclusive).
+	// AddSnap self-heals over the corrupt value planted above.
+	if err := w.AddSnap(ctx, catalog, stops[1], "oss://b/"+stops[1].String()+".snap"); err != nil {
+		t.Fatalf("AddSnap: %v", err)
+	}
+	if n, err = w.CompactDeltas(ctx, catalog); err != nil || n != 2 {
+		t.Fatalf("compact: removed=%d err=%v, want 2/nil", n, err)
+	}
+
+	// The read primitive sees the same world after compaction: snap at
+	// stops[1], exactly the one delta past it.
+	snap, rr := r.ListCatalog(ctx, catalog)
+	if rr.Err != nil {
+		t.Fatalf("ListCatalog after compact: %v", rr.Err)
+	}
+	if snap == nil || snap.StopTsSeq != stops[1] {
+		t.Fatalf("snap after compact: %+v, want stop=%v", snap, stops[1])
+	}
+	if len(rr.Deltas) != 1 || rr.Deltas[0].TsSeq != stops[2] {
+		t.Fatalf("deltas after compact: %+v, want single entry at %v", rr.Deltas, stops[2])
+	}
+
+	// Idempotent: nothing left at or below the stop.
+	if n, err = w.CompactDeltas(ctx, catalog); err != nil || n != 0 {
+		t.Fatalf("second compact: removed=%d err=%v, want 0/nil", n, err)
+	}
+}

--- a/internal/index/encoding.go
+++ b/internal/index/encoding.go
@@ -111,5 +111,29 @@ func DecodeSnapValue(value string) (TimeSeqID, string, error) {
 	return stop, arr[1], nil
 }
 
+// snapScoreLua defines snap_score(raw) → score|nil for use inside index Lua
+// scripts (prepend this const to the script body). It is the Lua mirror of
+// DecodeSnapValue + ParseTimeSeqID above and MUST accept exactly what they
+// accept: a 2-string [tsSeq, uri] with non-empty uri; ts with no leading zero
+// within the year-3000 cap; seq 1..999999 with no leading zero. Accepting
+// more would let a script trust a value the Go reader rejects (wedging the
+// catalog); accepting less would make it discard a valid snap. The "0_0"
+// sentinel deliberately yields nil: it scores 0, so no caller's comparison
+// against a real stop can need it.
+const snapScoreLua = `
+local function snap_score(raw)
+  local ok, arr = pcall(cjson.decode, raw)
+  if not (ok and type(arr) == "table" and type(arr[1]) == "string"
+        and type(arr[2]) == "string" and arr[2] ~= "") then
+    return nil
+  end
+  local ts, seq = string.match(arr[1], "^([1-9]%d*)_([1-9]%d?%d?%d?%d?%d?)$")
+  if not ts or tonumber(ts) > 32503680000 then
+    return nil
+  end
+  return tonumber(ts) + tonumber(seq) / 1000000.0
+end
+`
+
 // IsDeltaMember reports whether a zset member looks like a delta (JSON array).
 func IsDeltaMember(m string) bool { return len(m) > 0 && m[0] == '[' }

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -56,16 +57,96 @@ type BatchListResult struct {
 	ReadResult *ReadIndexResult
 }
 
-func (r *Reader) ReadAll(ctx context.Context, catalog string) *ReadIndexResult {
-	return r.readRange(ctx, catalog, "-inf", "+inf")
+// listScript reads the catalog's snap pointer and the deltas past it in ONE
+// atomic step. Atomicity is a correctness requirement, not an optimization:
+// with Compact in the picture, a non-atomic HGET→ZRANGE pair could observe an
+// old snap pointer, then a delta range already compacted up to a newer snap —
+// silently dropping the deltas in between from the merged document. Inside a
+// script nothing interleaves, and the snap pointer is monotonic (AddSnap), so
+// every read observes a consistent (snap, deltas-after-it) pair.
+//
+// A snap value snap_score rejects falls back to the full range; the Go side
+// then surfaces the decode error (parseListReply). KEYS[1] = snaps hash,
+// KEYS[2] = delta zset; ARGV[1] = catalog. Returns {snapValue|false, flat
+// [member, score, ...]} — scores pass through as Redis reply strings, never
+// via Lua numbers (tostring would mangle the float).
+const listScript = snapScoreLua + `
+local snap = redis.call("HGET", KEYS[1], ARGV[1])
+local min = "-inf"
+if snap then
+  local score = snap_score(snap)
+  if score then
+    min = "(" .. string.format("%.6f", score)
+  end
+end
+return {snap or false, redis.call("ZRANGEBYSCORE", KEYS[2], min, "+inf", "WITHSCORES")}
+`
+
+// ListCatalog atomically reads the snap pointer and the deltas past it —
+// the single read primitive behind Client.List / Client.BatchList.
+func (r *Reader) ListCatalog(ctx context.Context, catalog string) (*SnapInfo, *ReadIndexResult) {
+	res, err := r.rdb.Eval(ctx, listScript,
+		[]string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(catalog)},
+		catalog,
+	).Result()
+	if err != nil {
+		return nil, &ReadIndexResult{Catalog: catalog, Err: fmt.Errorf("list eval: %w", err)}
+	}
+	return r.parseListResult(catalog, res)
 }
 
-func (r *Reader) ReadSince(ctx context.Context, catalog string, sinceTimestamp float64) *ReadIndexResult {
-	return r.readRange(ctx, catalog, fmt.Sprintf("(%.6f", sinceTimestamp), "+inf")
+// parseListResult converts one listScript reply into (snap, deltas). An
+// undecodable snap value is an error, not a silent nil: the read path must
+// not fall back to replaying all deltas as if no snapshot existed (the full
+// log may long predate what the snapshot absorbed — or be compacted away).
+func (r *Reader) parseListResult(catalog string, res any) (*SnapInfo, *ReadIndexResult) {
+	rawSnap, zs, err := parseListReply(res)
+	if err != nil {
+		return nil, &ReadIndexResult{Catalog: catalog, Err: err}
+	}
+	var snap *SnapInfo
+	if rawSnap != "" {
+		stop, uri, derr := DecodeSnapValue(rawSnap)
+		if derr != nil {
+			return nil, &ReadIndexResult{Catalog: catalog, Err: fmt.Errorf("decode snap: %w", derr)}
+		}
+		snap = &SnapInfo{StopTsSeq: stop, URI: uri}
+	}
+	return snap, r.processZMembers(catalog, zs)
 }
 
-func (r *Reader) ReadRange(ctx context.Context, catalog string, minTimestamp, maxTimestamp float64) *ReadIndexResult {
-	return r.readRange(ctx, catalog, fmt.Sprintf("%.6f", minTimestamp), fmt.Sprintf("%.6f", maxTimestamp))
+// parseListReply unpacks the raw {snapValue|false, [member, score, ...]}
+// script reply. Scores arrive as Redis reply strings ("%.17g"), which
+// strconv.ParseFloat round-trips to the exact stored double — the same
+// fidelity go-redis gives ZRangeByScoreWithScores, so DecodeDeltaMember's
+// score-lockstep check keeps holding.
+func parseListReply(res any) (string, []redis.Z, error) {
+	arr, ok := res.([]any)
+	if !ok || len(arr) != 2 {
+		return "", nil, fmt.Errorf("unexpected list reply: %T", res)
+	}
+	rawSnap, _ := arr[0].(string) // Lua false → nil → not a string → ""
+	flat, ok := arr[1].([]any)
+	if !ok {
+		return "", nil, fmt.Errorf("unexpected list deltas reply: %T", arr[1])
+	}
+	if len(flat)%2 != 0 {
+		return "", nil, fmt.Errorf("odd WITHSCORES reply length: %d", len(flat))
+	}
+	zs := make([]redis.Z, 0, len(flat)/2)
+	for i := 0; i+1 < len(flat); i += 2 {
+		member, ok1 := flat[i].(string)
+		scoreStr, ok2 := flat[i+1].(string)
+		if !ok1 || !ok2 {
+			return "", nil, fmt.Errorf("unexpected member/score types: %T/%T", flat[i], flat[i+1])
+		}
+		score, perr := strconv.ParseFloat(scoreStr, 64)
+		if perr != nil {
+			return "", nil, fmt.Errorf("invalid score %q: %w", scoreStr, perr)
+		}
+		zs = append(zs, redis.Z{Member: member, Score: score})
+	}
+	return rawSnap, zs, nil
 }
 
 func (r *Reader) GetLatestSnap(ctx context.Context, catalog string) (*SnapInfo, error) {
@@ -127,68 +208,33 @@ func (r *Reader) IterateSnaps(ctx context.Context, fn func(catalog string, snap 
 	}
 }
 
-// BatchList runs an HMGet on snaps + a pipelined ZRange for every
-// catalog — 2 round-trips total regardless of catalog count.
+// BatchList runs one pipelined listScript per catalog — a single round-trip
+// regardless of catalog count, and each catalog's (snap, deltas) pair is
+// atomic on the server (per-catalog atomicity is all a reader needs; no
+// cross-catalog consistency is promised).
 func (r *Reader) BatchList(ctx context.Context, catalogs []string) map[string]*BatchListResult {
 	out := make(map[string]*BatchListResult, len(catalogs))
 	if len(catalogs) == 0 {
 		return out
 	}
-	for _, c := range catalogs {
-		out[c] = &BatchListResult{}
-	}
-
-	snapVals, err := r.rdb.HMGet(ctx, r.MakeSnapsHashKey(), catalogs...).Result()
-	if err != nil && err != redis.Nil {
-		for _, c := range catalogs {
-			out[c].ReadResult = &ReadIndexResult{Catalog: c, Err: fmt.Errorf("hmget snaps: %w", err)}
-		}
-		return out
-	}
-	for i, raw := range snapVals {
-		c := catalogs[i]
-		s, ok := raw.(string)
-		if !ok {
-			continue
-		}
-		stop, uri, err := DecodeSnapValue(s)
-		if err != nil {
-			out[c].ReadResult = &ReadIndexResult{Catalog: c, Err: fmt.Errorf("decode snap: %w", err)}
-			continue
-		}
-		out[c].Snap = &SnapInfo{StopTsSeq: stop, URI: uri}
-	}
 
 	pipe := r.rdb.Pipeline()
-	cmds := make(map[string]*redis.ZSliceCmd, len(catalogs))
+	cmds := make(map[string]*redis.Cmd, len(catalogs))
 	for _, c := range catalogs {
-		if out[c].ReadResult != nil && out[c].ReadResult.Err != nil {
-			continue
-		}
-		min := "-inf"
-		if out[c].Snap != nil {
-			min = fmt.Sprintf("(%.6f", out[c].Snap.StopTsSeq.Score())
-		}
-		cmds[c] = pipe.ZRangeByScoreWithScores(ctx, r.MakeDeltaZsetKey(c), &redis.ZRangeBy{Min: min, Max: "+inf"})
+		out[c] = &BatchListResult{}
+		cmds[c] = pipe.Eval(ctx, listScript,
+			[]string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(c)}, c)
 	}
 	pipe.Exec(ctx)
 	for c, cmd := range cmds {
-		zs, err := cmd.Result()
-		if err != nil && err != redis.Nil {
-			out[c].ReadResult = &ReadIndexResult{Catalog: c, Err: fmt.Errorf("zrange: %w", err)}
+		res, err := cmd.Result()
+		if err != nil {
+			out[c].ReadResult = &ReadIndexResult{Catalog: c, Err: fmt.Errorf("list eval: %w", err)}
 			continue
 		}
-		out[c].ReadResult = r.processZMembers(c, zs)
+		out[c].Snap, out[c].ReadResult = r.parseListResult(c, res)
 	}
 	return out
-}
-
-func (r *Reader) readRange(ctx context.Context, catalog, min, max string) *ReadIndexResult {
-	zs, err := r.rdb.ZRangeByScoreWithScores(ctx, r.MakeDeltaZsetKey(catalog), &redis.ZRangeBy{Min: min, Max: max}).Result()
-	if err != nil {
-		return &ReadIndexResult{Catalog: catalog, Err: err}
-	}
-	return r.processZMembers(catalog, zs)
 }
 
 // processZMembers parses zset entries into deltas. V3 has no pending

--- a/internal/index/writer_snap.go
+++ b/internal/index/writer_snap.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -22,27 +23,15 @@ func NewWriter(rdb *redis.Client) *Writer {
 // across processes: without the guard, a slow save computed at an older stop
 // could land after a newer one and regress the snap pointer (correct but
 // wasteful — every read replays more deltas until it heals). A stored value
-// that fails to decode is treated as absent and overwritten (self-heal).
-// Returns 1 when the entry was written, 0 when the stored snap was kept.
-//
-// The keep branch must accept only values DecodeSnapValue (encoding.go) +
-// ParseTimeSeqID (timeseqid.go) accept — keeping anything the Go reader
-// rejects would wedge the catalog (GetLatestSnap fails, and no later AddSnap
-// could overwrite). Hence the full mirror of the Go rules: a 2-string
-// [tsSeq, uri] with non-empty uri; ts with no leading zero, ≤ year-3000 cap;
-// seq 1..999999 with no leading zero. (The "0_0" sentinel deliberately fails
-// the match: it scores 0, so any real stop would overwrite it anyway.)
-const addSnapScript = `
+// snap_score rejects (see snapScoreLua, encoding.go) is treated as absent and
+// overwritten (self-heal). Returns 1 when the entry was written, 0 when the
+// stored snap was kept.
+const addSnapScript = snapScoreLua + `
 local cur = redis.call("HGET", KEYS[1], ARGV[1])
 if cur then
-  local ok, arr = pcall(cjson.decode, cur)
-  if ok and type(arr) == "table" and type(arr[1]) == "string"
-        and type(arr[2]) == "string" and arr[2] ~= "" then
-    local ts, seq = string.match(arr[1], "^([1-9]%d*)_([1-9]%d?%d?%d?%d?%d?)$")
-    if ts and tonumber(ts) <= 32503680000
-          and tonumber(ts) + tonumber(seq) / 1000000.0 >= tonumber(ARGV[3]) then
-      return 0
-    end
+  local score = snap_score(cur)
+  if score and score >= tonumber(ARGV[3]) then
+    return 0
   end
 end
 redis.call("HSET", KEYS[1], ARGV[1], ARGV[2])
@@ -62,4 +51,40 @@ func (w *Writer) AddSnap(ctx context.Context, catalog string, stopTsSeq TimeSeqI
 		[]string{w.MakeSnapsHashKey()},
 		catalog, val, stopTsSeq.Score(),
 	).Err()
+}
+
+// compactDeltasScript removes every delta zset entry the catalog's current
+// snapshot has absorbed: score ≤ the snap's stop score, inclusive — the read
+// path fetches deltas strictly AFTER the stop (listScript, reader.go), so an
+// absorbed delta can never be read again. Missing or undecodable snap → 0
+// (never trim on a pointer the Go reader would reject). Returns the number
+// of entries removed.
+const compactDeltasScript = snapScoreLua + `
+local cur = redis.call("HGET", KEYS[1], ARGV[1])
+if not cur then
+  return 0
+end
+local score = snap_score(cur)
+if not score then
+  return 0
+end
+return redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", string.format("%.6f", score))
+`
+
+// CompactDeltas trims the catalog's delta zset up to (and including) the
+// current snap stop, atomically with reading the snap pointer. Only index
+// entries are removed — delta objects in storage are untouched.
+func (w *Writer) CompactDeltas(ctx context.Context, catalog string) (int64, error) {
+	res, err := w.rdb.Eval(ctx, compactDeltasScript,
+		[]string{w.MakeSnapsHashKey(), w.MakeDeltaZsetKey(catalog)},
+		catalog,
+	).Result()
+	if err != nil {
+		return 0, fmt.Errorf("compact eval: %w", err)
+	}
+	n, ok := res.(int64)
+	if !ok {
+		return 0, fmt.Errorf("unexpected compact result: %v", res)
+	}
+	return n, nil
 }

--- a/list.go
+++ b/list.go
@@ -73,8 +73,9 @@ func (m ListResult) Dump() string {
 	return b.String()
 }
 
-// List reads the catalog metadata in two Redis ops (HGet snap + ZRange
-// deltas).
+// List reads the catalog metadata in one atomic Redis op (a Lua script
+// fetches the snap pointer and the deltas past it together — atomicity is
+// what makes Compact safe to run concurrently with reads).
 func (c *Client) List(ctx context.Context, catalog string) *ListResult {
 	c.emitEvent(catalog, "List", nil)
 
@@ -82,16 +83,7 @@ func (c *Client) List(ctx context.Context, catalog string) *ListResult {
 		return &ListResult{client: c, catalog: catalog, Err: err}
 	}
 
-	snap, err := c.reader.GetLatestSnap(ctx, catalog)
-	if err != nil {
-		return &ListResult{client: c, catalog: catalog, Err: fmt.Errorf("get snapshot: %w", err)}
-	}
-	var rr *index.ReadIndexResult
-	if snap != nil {
-		rr = c.reader.ReadSince(ctx, catalog, snap.StopTsSeq.Score())
-	} else {
-		rr = c.reader.ReadAll(ctx, catalog)
-	}
+	snap, rr := c.reader.ListCatalog(ctx, catalog)
 	return &ListResult{
 		client:     c,
 		catalog:    catalog,
@@ -101,7 +93,7 @@ func (c *Client) List(ctx context.Context, catalog string) *ListResult {
 	}
 }
 
-// BatchList runs List for many catalogs in 2 Redis round-trips total.
+// BatchList runs List for many catalogs in one pipelined Redis round-trip.
 func (c *Client) BatchList(ctx context.Context, catalogs []string) map[string]*ListResult {
 	out := make(map[string]*ListResult, len(catalogs))
 	for _, cat := range catalogs {


### PR DESCRIPTION
Implements the compaction tooling deferred since v3-alpha ("No background compaction (yet)"). All of `go vet`, `go test ./...`, and `go test -race ./...` pass; every new behavior is pinned against a live Redis.

## What's new

**`Compact(ctx, catalog) (int64, error)`** — trims the delta zset up to (and including) the current snapshot stop, i.e. exactly the entries the read path can never fetch again, and returns how many were removed.

- **Index-only by design.** Delta objects in storage are untouched: they remain portable history, and object deletion belongs to bucket lifecycle rules, not Lake. Compaction changes no read result — only reclaims Redis memory.
- **Never trims on an untrusted pointer.** No snap, or a snap value the Go reader rejects, is a no-op — the same "keep-branch must mirror the Go decoder" rule from #11.
- **Explicit, no background reaper** — sweep on your own schedule, e.g. via `IterateSnaps`.

## Why the read path changed too

Compaction is only sound if a read can never pair a *stale* snap pointer with an *already-compacted* delta range. With the old two-op read (HGet snap → ZRange deltas), this interleaving loses data silently:

```
reader: HGet snap        → sees S0
        (a newer snapshot S1 lands; Compact trims deltas ≤ S1)
reader: ZRange (S0, +inf) → deltas (S0, S1] are gone → silent hole in the merged doc
```

So `List` now reads (snap pointer, deltas after it) in **one atomic Lua script** — nothing can interleave inside a script, and the monotonic snap pointer (from #11) covers the rest. Side benefits: `List` drops from 2 Redis round-trips to 1, `BatchList` from 2 to 1 pipelined round-trip with per-catalog atomicity. The now-unused `ReadAll`/`ReadSince`/`ReadRange` are removed.

Scores pass through the script as Redis reply strings (never Lua numbers, whose `tostring` would mangle the float), so `DecodeDeltaMember`'s score-lockstep check keeps holding — pinned by the existing live-Redis consistency test.

## Single source of truth for snap decoding in Lua

The snap-value validation needed by three scripts (addSnap guard, list, compact) is extracted into one helper, `snapScoreLua`, placed in `encoding.go` next to its Go mirror (`DecodeSnapValue` + `ParseTimeSeqID`) so the two languages can't drift apart.

## Tests

- `TestCompactDeltas` (index, live Redis): no-snap no-op, corrupt-snap no-op, inclusive trim bound, idempotency, survivors visible through the read primitive.
- `TestCompactRoundTrip_Redis` (client, live Redis): document identical before/after compaction (snapshot-only read), post-compact writes merge correctly, compact before the next snapshot removes nothing.
- README updated: read-path description and the compaction section.

https://claude.ai/code/session_01VqJozJxfijWpZpmVW53Xac

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqJozJxfijWpZpmVW53Xac)_