### PR TITLE
fix: validate replace bodies; per-writer temp files; fresher sample stamps

### DIFF
--- a/internal/merge/replace.go
+++ b/internal/merge/replace.go
@@ -20,12 +20,19 @@ func NewReplaceMerger() *ReplaceMerger {
 // data: the new value to set
 // field: the field path to replace (empty "" means root document)
 // Returns: the result with replaced value
+//
+// data is validated for EVERY replace, not just root: it is a client-uploaded
+// body Lake never inspected before this point, and sjson.SetRawBytes splices
+// raw bytes verbatim — an invalid body would silently corrupt the whole
+// document (and the snapshot then persisted from it) instead of failing loudly
+// with the offending delta identified.
 func (m *ReplaceMerger) Merge(original, data []byte, field string) ([]byte, error) {
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("invalid JSON body for replace")
+	}
+
 	// If field is empty, replace entire document
 	if field == "" {
-		if !json.Valid(data) {
-			return nil, fmt.Errorf("invalid JSON for root replace")
-		}
 		return data, nil
 	}
 

--- a/internal/merge/replace_test.go
+++ b/internal/merge/replace_test.go
@@ -101,3 +101,18 @@ func TestReplaceMerger_RejectsInvalidRootJSON(t *testing.T) {
 		t.Fatal("root replace must reject invalid JSON")
 	}
 }
+
+// TestReplaceMerger_RejectsInvalidFieldJSON pins the guard on the FIELD
+// replace path: bodies are client uploads Lake never inspected, and
+// sjson.SetRawBytes splices raw bytes verbatim — without the validation an
+// invalid body silently corrupts the merged document (err == nil, doc no
+// longer JSON) instead of failing with the offending delta identified.
+func TestReplaceMerger_RejectsInvalidFieldJSON(t *testing.T) {
+	merger := NewReplaceMerger()
+	for _, bad := range []string{`{invalid`, `not json`, ``, `{"a":1}garbage`} {
+		res, err := merger.Merge([]byte(`{"x":1}`), []byte(bad), "f")
+		if err == nil {
+			t.Fatalf("field replace accepted invalid body %q → %q", bad, res)
+		}
+	}
+}

--- a/poison_body_test.go
+++ b/poison_body_test.go
@@ -1,0 +1,64 @@
+package lake
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hkloudou/lake/v3/storage"
+	"github.com/hkloudou/lake/v3/storage/mem"
+)
+
+// TestPoisonBodyFailsLoudly_Redis pins the contract for a body Lake never
+// inspects: a client uploads garbage to its presigned location, Notify
+// records the delta, and the read must FAIL with the offending delta
+// identified — not silently splice the garbage into the merged document and
+// then persist that corruption as the catalog's snapshot (which would poison
+// every later read).
+func TestPoisonBodyFailsLoudly_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve, WithSnapTarget("mem", "snaps"))
+
+	ctx := context.Background()
+	h, err := c.WriteBegin(ctx, WriteBeginRequest{
+		Catalog: "users", Path: "/profile", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+	})
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+	// The "upload": invalid JSON, exactly what a buggy or malicious client
+	// can put at the presigned URL.
+	if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(`{invalid`)); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := c.WriteNotify(ctx, h); err != nil {
+		t.Fatalf("WriteNotify: %v", err)
+	}
+
+	list := c.List(ctx, "users")
+	if list.Err != nil {
+		t.Fatalf("List: %v", list.Err)
+	}
+	_, err = ReadString(ctx, list)
+	if err == nil {
+		t.Fatal("read of a poison body must fail, not return a corrupt document")
+	}
+	// The error must carry what an operator needs to locate the delta.
+	for _, want := range []string{list.Entries[0].TsSeq.String(), h.URI} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should identify the offending delta (%s): %v", want, err)
+		}
+	}
+
+	// The failed read must not have snapshotted anything.
+	if snap, _ := c.reader.GetLatestSnap(ctx, "users"); snap != nil {
+		t.Fatalf("a failed read must not persist a snapshot, got %+v", snap)
+	}
+}

--- a/sample.go
+++ b/sample.go
@@ -250,7 +250,10 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 		wg.Go(func() {
 			for cat := range jobs {
 				l := lists[cat]
-				v, e := s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), now))
+				// Re-read the clock per loader run: with many misses ahead in
+				// the queue, the batch-start `now` could stamp an UpdatedAt
+				// already a whole maxAge in the past.
+				v, e := s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), c.reader.NowUnix()))
 				mu.Lock()
 				out[cat] = &SampleResult[T]{Value: v, Err: e}
 				mu.Unlock()

--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -85,15 +85,33 @@ func (v *view) Put(_ context.Context, _ /*catalog*/, path string, data []byte) e
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+	dir := filepath.Dir(full)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("file: mkdir: %w", err)
 	}
-	tmp := full + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	// Unique temp name per writer: concurrent Puts of the same path (e.g. two
+	// processes racing to save the same snapshot) must not interleave writes
+	// into one shared "<path>.tmp" — each stages its own file, and the final
+	// rename stays atomic.
+	tmp, err := os.CreateTemp(dir, filepath.Base(full)+".tmp*")
+	if err != nil {
+		return fmt.Errorf("file: create tmp: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
 		return fmt.Errorf("file: write tmp: %w", err)
 	}
-	if err := os.Rename(tmp, full); err != nil {
-		os.Remove(tmp)
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return fmt.Errorf("file: close tmp: %w", err)
+	}
+	if err := os.Chmod(tmp.Name(), 0o644); err != nil {
+		os.Remove(tmp.Name())
+		return fmt.Errorf("file: chmod tmp: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), full); err != nil {
+		os.Remove(tmp.Name())
 		return fmt.Errorf("file: rename: %w", err)
 	}
 	return nil

--- a/storage/file/file_test.go
+++ b/storage/file/file_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -23,6 +24,55 @@ func TestFile_RoundTrip(t *testing.T) {
 	}
 	if string(got) != "hello" {
 		t.Fatalf("Get = %q, want hello", got)
+	}
+}
+
+// TestFile_ConcurrentPutSamePath pins the staging contract: every writer
+// stages through its OWN temp file, so racing Puts of one path never
+// interleave bytes — the final content is exactly one writer's payload, and
+// no *.tmp* staging file survives.
+func TestFile_ConcurrentPutSamePath(t *testing.T) {
+	fs, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := fs.Bucket("data")
+	ctx := context.Background()
+
+	payload := func(i int) []byte {
+		return append([]byte{byte('a' + i)}, make([]byte, 64*1024)...)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Go(func() {
+			if err := b.Put(ctx, "users", "x.snap", payload(i)); err != nil {
+				t.Errorf("Put: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	got, err := b.Get(ctx, "users", "x.snap")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	var whole bool
+	for i := 0; i < 8; i++ {
+		if string(got) == string(payload(i)) {
+			whole = true
+			break
+		}
+	}
+	if !whole {
+		t.Fatalf("content is not any single writer's payload (len=%d, first byte %q) — writes interleaved", len(got), got[0])
+	}
+
+	matches, err := filepath.Glob(filepath.Join(fs.base, "data", "*.tmp*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("staging files left behind: %v", matches)
 	}
 }
 


### PR DESCRIPTION
Second full-audit round. Three fixes, ranked; `go vet` / `go test` / `go test -race` all pass, integration tests ran against live Redis.

## 1. Field replace silently spliced invalid bodies into the document (merge)

Bodies are client uploads Lake never inspects — and `sjson.SetRawBytes` splices raw bytes **verbatim, without validation**. Root replace already had a `json.Valid` guard; field replace did not. Verified experimentally:

```
sjson.SetRawBytes({"x":1}, "f", `{invalid`) → `{"x":1,"f":{invalid}`, err == nil
```

So one garbage upload to a presigned URL made the merged document invalid JSON *silently*: the corrupt bytes were returned to the caller AND persisted as the catalog's snapshot — after which every later read fails at the merge base, permanently. Field replace now validates the body like root replace; the read fails loudly with the offending delta's tsSeq/URI, and a failed read never snapshots. `TestPoisonBodyFailsLoudly_Redis` pins the full path end-to-end (garbage upload → notify → read errors with locator → no snapshot indexed).

Also verified (no change needed): evanphx `MergePatch` handles non-object targets per RFC 7396 (array/scalar target + object patch → patch applied to `{}`), invalid RFC7396 patches error loudly, and sjson errors on setting an object key into a root array.

## 2. Shared temp file for concurrent same-path Puts (storage/file)

`Put` staged every write of a path through one shared `<path>.tmp` — two processes racing to save the same snapshot could interleave writes into the staging file before rename. Now each writer stages through its own `os.CreateTemp` file (mode fixed to 0644 before rename); the rename stays atomic. `TestFile_ConcurrentPutSamePath` races 8 writers under `-race` and asserts the final content is exactly one writer's payload with no staging files left behind.

## 3. Stale `UpdatedAt` stamps in Sampler.Batch (sample)

`Batch` read the Redis clock once, then stamped every miss's `UpdatedAt` with that batch-start time. With many misses queued behind slow loaders, entries could be stamped an entire `maxAge` in the past — forcing an immediate recompute on the next probe. The clock is now read per loader run.

https://claude.ai/code/session_01VqJozJxfijWpZpmVW53Xac

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqJozJxfijWpZpmVW53Xac)_