### PR TITLE
feat: RemoveDelta escape hatch, InvalidateSamples, HMAC-signed handles

### DIFF
--- a/internal/index/compact_test.go
+++ b/internal/index/compact_test.go
@@ -52,7 +52,7 @@ func TestCompactDeltas(t *testing.T) {
 
 	// Snap at the 2nd delta absorbs the first two (bound is inclusive).
 	// AddSnap self-heals over the corrupt value planted above.
-	if err := w.AddSnap(ctx, catalog, stops[1], "oss://b/"+stops[1].String()+".snap"); err != nil {
+	if err := w.AddSnap(ctx, catalog, stops[1], "oss://b/"+stops[1].String()+".snap", ""); err != nil {
 		t.Fatalf("AddSnap: %v", err)
 	}
 	if n, err = w.CompactDeltas(ctx, catalog); err != nil || n != 2 {

--- a/internal/index/indexIO.go
+++ b/internal/index/indexIO.go
@@ -43,3 +43,16 @@ func (w *indexIO) MakeSampleIndicatorKey(indicator string) string {
 	w.requirePrefix()
 	return fmt.Sprintf("%s:m:%s", w.prefix, encode.EncodeRedisCatalogName(indicator))
 }
+
+// MakeSampleRemoveGenKey: deployment-wide catalog-level sample removal
+// generation Hash "<prefix>:mrg", with catalog as field. Unlike the
+// per-indicator epoch (which lives inside each memo hash and so cannot
+// guard an indicator that has never cached anything), this key is created
+// by the first HINCRBY — it exists independently of any memo hash, so a
+// RemoveDelta can void in-flight sample writes for indicators Lake has
+// never seen. Cannot collide with "<prefix>:m:<indicator>" (that form
+// always has a second ":").
+func (w *indexIO) MakeSampleRemoveGenKey() string {
+	w.requirePrefix()
+	return fmt.Sprintf("%s:mrg", w.prefix)
+}

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -165,6 +165,21 @@ func parseListReply(res any) (string, string, []redis.Z, error) {
 	return rawSnap, removeGen, zs, nil
 }
 
+// RemoveGen returns the catalog's current removal generation ("0" if no
+// delta was ever removed). Sample write-backs recheck it against the
+// generation captured with their ListResult: a loader computing from a list
+// taken BEFORE a removal must not cache its result after it.
+func (r *Reader) RemoveGen(ctx context.Context, catalog string) (string, error) {
+	gen, err := r.rdb.HGet(ctx, r.MakeSnapsHashKey(), catalog+":rg").Result()
+	if err == redis.Nil {
+		return "0", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return gen, nil
+}
+
 func (r *Reader) GetLatestSnap(ctx context.Context, catalog string) (*SnapInfo, error) {
 	val, err := r.rdb.HGet(ctx, r.MakeSnapsHashKey(), catalog).Result()
 	if err == redis.Nil {

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -49,7 +49,13 @@ type DeltaInfo struct {
 type ReadIndexResult struct {
 	Catalog string
 	Deltas  []DeltaInfo
-	Err     error
+	// RemoveGen is the catalog's removal generation observed atomically with
+	// this read ("0" until the first RemoveDelta). AddSnap refuses a snapshot
+	// carrying a stale generation, so a read that listed a delta which was
+	// removed while the read was in flight can never persist that delta's
+	// effect into a snapshot.
+	RemoveGen string
+	Err       error
 }
 
 type BatchListResult struct {
@@ -66,12 +72,16 @@ type BatchListResult struct {
 // every read observes a consistent (snap, deltas-after-it) pair.
 //
 // A snap value snap_score rejects falls back to the full range; the Go side
-// then surfaces the decode error (parseListReply). KEYS[1] = snaps hash,
-// KEYS[2] = delta zset; ARGV[1] = catalog. Returns {snapValue|false, flat
-// [member, score, ...]} — scores pass through as Redis reply strings, never
-// via Lua numbers (tostring would mangle the float).
+// then surfaces the decode error (parseListReply). The removal generation
+// ("<catalog>:rg" field of the snaps hash, absent = "0") is read in the same
+// atomic step so AddSnap can later tell whether a RemoveDelta interleaved.
+// KEYS[1] = snaps hash, KEYS[2] = delta zset; ARGV[1] = catalog. Returns
+// {snapValue|false, removeGen, flat [member, score, ...]} — scores pass
+// through as Redis reply strings, never via Lua numbers (tostring would
+// mangle the float).
 const listScript = snapScoreLua + `
 local snap = redis.call("HGET", KEYS[1], ARGV[1])
+local rg = redis.call("HGET", KEYS[1], ARGV[1] .. ":rg") or "0"
 local min = "-inf"
 if snap then
   local score = snap_score(snap)
@@ -79,7 +89,7 @@ if snap then
     min = "(" .. string.format("%.6f", score)
   end
 end
-return {snap or false, redis.call("ZRANGEBYSCORE", KEYS[2], min, "+inf", "WITHSCORES")}
+return {snap or false, rg, redis.call("ZRANGEBYSCORE", KEYS[2], min, "+inf", "WITHSCORES")}
 `
 
 // ListCatalog atomically reads the snap pointer and the deltas past it —
@@ -100,7 +110,7 @@ func (r *Reader) ListCatalog(ctx context.Context, catalog string) (*SnapInfo, *R
 // not fall back to replaying all deltas as if no snapshot existed (the full
 // log may long predate what the snapshot absorbed — or be compacted away).
 func (r *Reader) parseListResult(catalog string, res any) (*SnapInfo, *ReadIndexResult) {
-	rawSnap, zs, err := parseListReply(res)
+	rawSnap, removeGen, zs, err := parseListReply(res)
 	if err != nil {
 		return nil, &ReadIndexResult{Catalog: catalog, Err: err}
 	}
@@ -112,41 +122,47 @@ func (r *Reader) parseListResult(catalog string, res any) (*SnapInfo, *ReadIndex
 		}
 		snap = &SnapInfo{StopTsSeq: stop, URI: uri}
 	}
-	return snap, r.processZMembers(catalog, zs)
+	rr := r.processZMembers(catalog, zs)
+	rr.RemoveGen = removeGen
+	return snap, rr
 }
 
-// parseListReply unpacks the raw {snapValue|false, [member, score, ...]}
-// script reply. Scores arrive as Redis reply strings ("%.17g"), which
-// strconv.ParseFloat round-trips to the exact stored double — the same
+// parseListReply unpacks the raw {snapValue|false, removeGen, [member,
+// score, ...]} script reply. Scores arrive as Redis reply strings ("%.17g"),
+// which strconv.ParseFloat round-trips to the exact stored double — the same
 // fidelity go-redis gives ZRangeByScoreWithScores, so DecodeDeltaMember's
 // score-lockstep check keeps holding.
-func parseListReply(res any) (string, []redis.Z, error) {
+func parseListReply(res any) (string, string, []redis.Z, error) {
 	arr, ok := res.([]any)
-	if !ok || len(arr) != 2 {
-		return "", nil, fmt.Errorf("unexpected list reply: %T", res)
+	if !ok || len(arr) != 3 {
+		return "", "", nil, fmt.Errorf("unexpected list reply: %T", res)
 	}
 	rawSnap, _ := arr[0].(string) // Lua false → nil → not a string → ""
-	flat, ok := arr[1].([]any)
+	removeGen, ok := arr[1].(string)
 	if !ok {
-		return "", nil, fmt.Errorf("unexpected list deltas reply: %T", arr[1])
+		return "", "", nil, fmt.Errorf("unexpected remove-gen reply: %T", arr[1])
+	}
+	flat, ok := arr[2].([]any)
+	if !ok {
+		return "", "", nil, fmt.Errorf("unexpected list deltas reply: %T", arr[2])
 	}
 	if len(flat)%2 != 0 {
-		return "", nil, fmt.Errorf("odd WITHSCORES reply length: %d", len(flat))
+		return "", "", nil, fmt.Errorf("odd WITHSCORES reply length: %d", len(flat))
 	}
 	zs := make([]redis.Z, 0, len(flat)/2)
 	for i := 0; i+1 < len(flat); i += 2 {
 		member, ok1 := flat[i].(string)
 		scoreStr, ok2 := flat[i+1].(string)
 		if !ok1 || !ok2 {
-			return "", nil, fmt.Errorf("unexpected member/score types: %T/%T", flat[i], flat[i+1])
+			return "", "", nil, fmt.Errorf("unexpected member/score types: %T/%T", flat[i], flat[i+1])
 		}
 		score, perr := strconv.ParseFloat(scoreStr, 64)
 		if perr != nil {
-			return "", nil, fmt.Errorf("invalid score %q: %w", scoreStr, perr)
+			return "", "", nil, fmt.Errorf("invalid score %q: %w", scoreStr, perr)
 		}
 		zs = append(zs, redis.Z{Member: member, Score: score})
 	}
-	return rawSnap, zs, nil
+	return rawSnap, removeGen, zs, nil
 }
 
 func (r *Reader) GetLatestSnap(ctx context.Context, catalog string) (*SnapInfo, error) {

--- a/internal/index/reader_snap_hash_test.go
+++ b/internal/index/reader_snap_hash_test.go
@@ -59,7 +59,7 @@ func TestSnapHashRoundTrip(t *testing.T) {
 	stop := TimeSeqID{Timestamp: 1700000100, SeqID: 500}
 	uri := "oss://my-bucket/4f3a/(users/1700000100_500.snap"
 
-	if err := w.AddSnap(ctx, "users", stop, uri); err != nil {
+	if err := w.AddSnap(ctx, "users", stop, uri, ""); err != nil {
 		t.Fatalf("AddSnap: %v", err)
 	}
 
@@ -103,10 +103,10 @@ func TestSnapHashOverwrite(t *testing.T) {
 	stop1 := TimeSeqID{Timestamp: 1700000100, SeqID: 500}
 	stop2 := TimeSeqID{Timestamp: 1700000200, SeqID: 999}
 
-	if err := w.AddSnap(ctx, "users", stop1, "oss://b/"+stop1.String()+".snap"); err != nil {
+	if err := w.AddSnap(ctx, "users", stop1, "oss://b/"+stop1.String()+".snap", ""); err != nil {
 		t.Fatalf("first AddSnap: %v", err)
 	}
-	if err := w.AddSnap(ctx, "users", stop2, "oss://b/"+stop2.String()+".snap"); err != nil {
+	if err := w.AddSnap(ctx, "users", stop2, "oss://b/"+stop2.String()+".snap", ""); err != nil {
 		t.Fatalf("second AddSnap: %v", err)
 	}
 
@@ -143,15 +143,15 @@ func TestSnapHashMonotonic(t *testing.T) {
 	older := TimeSeqID{Timestamp: 1700000100, SeqID: 500}
 	newer := TimeSeqID{Timestamp: 1700000200, SeqID: 1}
 
-	if err := w.AddSnap(ctx, "users", newer, "oss://b/"+newer.String()+".snap"); err != nil {
+	if err := w.AddSnap(ctx, "users", newer, "oss://b/"+newer.String()+".snap", ""); err != nil {
 		t.Fatalf("AddSnap newer: %v", err)
 	}
 	// A late save at an older stop is silently dropped.
-	if err := w.AddSnap(ctx, "users", older, "oss://b/"+older.String()+".snap"); err != nil {
+	if err := w.AddSnap(ctx, "users", older, "oss://b/"+older.String()+".snap", ""); err != nil {
 		t.Fatalf("AddSnap older: %v", err)
 	}
 	// Same stop, different uri: stored entry wins.
-	if err := w.AddSnap(ctx, "users", newer, "oss://elsewhere/"+newer.String()+".snap"); err != nil {
+	if err := w.AddSnap(ctx, "users", newer, "oss://elsewhere/"+newer.String()+".snap", ""); err != nil {
 		t.Fatalf("AddSnap equal: %v", err)
 	}
 
@@ -185,7 +185,7 @@ func TestSnapHashMonotonic(t *testing.T) {
 		if err := rdb.HSet(ctx, r.MakeSnapsHashKey(), "users", corrupt).Err(); err != nil {
 			t.Fatalf("HSet corrupt %q: %v", corrupt, err)
 		}
-		if err := w.AddSnap(ctx, "users", older, "oss://b/"+older.String()+".snap"); err != nil {
+		if err := w.AddSnap(ctx, "users", older, "oss://b/"+older.String()+".snap", ""); err != nil {
 			t.Fatalf("AddSnap over corrupt %q: %v", corrupt, err)
 		}
 		got, err = r.GetLatestSnap(ctx, "users")
@@ -216,7 +216,7 @@ func TestIterateSnapsBatchBackup(t *testing.T) {
 	}
 
 	for catalog, stop := range stops {
-		if err := w.AddSnap(ctx, catalog, stop, "oss://b/"+stop.String()+".snap"); err != nil {
+		if err := w.AddSnap(ctx, catalog, stop, "oss://b/"+stop.String()+".snap", ""); err != nil {
 			t.Fatalf("AddSnap %s: %v", catalog, err)
 		}
 	}
@@ -273,7 +273,7 @@ func TestIterateSnapsEarlyStop(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		cat := fmt.Sprintf("c%02d", i)
 		ts := TimeSeqID{Timestamp: 1700000000 + int64(i), SeqID: 1}
-		if err := w.AddSnap(ctx, cat, ts, "oss://b/"+ts.String()+".snap"); err != nil {
+		if err := w.AddSnap(ctx, cat, ts, "oss://b/"+ts.String()+".snap", ""); err != nil {
 			t.Fatalf("AddSnap %s: %v", cat, err)
 		}
 	}

--- a/internal/index/writer_delta.go
+++ b/internal/index/writer_delta.go
@@ -1,0 +1,43 @@
+package index
+
+import (
+	"context"
+	"fmt"
+)
+
+// removeDeltaScript removes exactly one delta entry, located by its score and
+// verified by the tsSeq embedded in the member (arr[3] of the JSON array
+// [mergeType, path, tsSeq, uri]) — never by member-string equality, which an
+// operator cannot be expected to reproduce byte-for-byte. Scores are unique
+// per (catalog, tsSeq) allocation, but the loop tolerates hand-planted
+// duplicates and removes only the matching member. Returns 1 if removed,
+// 0 if no entry at that tsSeq. KEYS[1] = delta zset; ARGV[1] = score,
+// ARGV[2] = tsSeq string.
+const removeDeltaScript = `
+local members = redis.call("ZRANGEBYSCORE", KEYS[1], ARGV[1], ARGV[1])
+for _, m in ipairs(members) do
+  local ok, arr = pcall(cjson.decode, m)
+  if ok and type(arr) == "table" and arr[3] == ARGV[2] then
+    redis.call("ZREM", KEYS[1], m)
+    return 1
+  end
+end
+return 0
+`
+
+// RemoveDelta deletes the delta index entry with the given tsSeq. The body
+// object in storage is untouched. Returns whether an entry was removed.
+func (w *Writer) RemoveDelta(ctx context.Context, catalog string, tsSeq TimeSeqID) (bool, error) {
+	res, err := w.rdb.Eval(ctx, removeDeltaScript,
+		[]string{w.MakeDeltaZsetKey(catalog)},
+		tsSeq.Score(), tsSeq.String(),
+	).Result()
+	if err != nil {
+		return false, fmt.Errorf("remove delta eval: %w", err)
+	}
+	n, ok := res.(int64)
+	if !ok {
+		return false, fmt.Errorf("unexpected remove delta result: %v", res)
+	}
+	return n == 1, nil
+}

--- a/internal/index/writer_delta.go
+++ b/internal/index/writer_delta.go
@@ -17,6 +17,13 @@ import (
 // computed from an older generation, so an in-flight read that listed the
 // removed delta can never persist its effect (see addSnapScript).
 //
+// The bump comes BEFORE the ZREM: Redis Lua does not roll back on error, so
+// if the HINCRBY can fail (a hand-corrupted non-integer ":rg" field), it
+// must fail while the delta is still present — the reverse order would
+// leave the delta gone with the generation unmoved, and an in-flight
+// old-generation snapshot could then resurrect it. A bump whose ZREM then
+// cannot fail (plain ZREM never errors) needs no compensation.
+//
 // Returns 1 if removed, 0 if no entry at that tsSeq. KEYS[1] = delta zset,
 // KEYS[2] = snaps hash; ARGV[1] = score, ARGV[2] = tsSeq, ARGV[3] = catalog.
 const removeDeltaScript = `
@@ -24,8 +31,8 @@ local members = redis.call("ZRANGEBYSCORE", KEYS[1], ARGV[1], ARGV[1])
 for _, m in ipairs(members) do
   local ok, arr = pcall(cjson.decode, m)
   if ok and type(arr) == "table" and arr[3] == ARGV[2] then
-    redis.call("ZREM", KEYS[1], m)
     redis.call("HINCRBY", KEYS[2], ARGV[3] .. ":rg", 1)
+    redis.call("ZREM", KEYS[1], m)
     return 1
   end
 end

--- a/internal/index/writer_delta.go
+++ b/internal/index/writer_delta.go
@@ -10,27 +10,35 @@ import (
 // [mergeType, path, tsSeq, uri]) — never by member-string equality, which an
 // operator cannot be expected to reproduce byte-for-byte. Scores are unique
 // per (catalog, tsSeq) allocation, but the loop tolerates hand-planted
-// duplicates and removes only the matching member. Returns 1 if removed,
-// 0 if no entry at that tsSeq. KEYS[1] = delta zset; ARGV[1] = score,
-// ARGV[2] = tsSeq string.
+// duplicates and removes only the matching member.
+//
+// On success it also bumps the catalog's removal generation ("<catalog>:rg"
+// in the snaps hash) in the same atomic step; AddSnap refuses a snapshot
+// computed from an older generation, so an in-flight read that listed the
+// removed delta can never persist its effect (see addSnapScript).
+//
+// Returns 1 if removed, 0 if no entry at that tsSeq. KEYS[1] = delta zset,
+// KEYS[2] = snaps hash; ARGV[1] = score, ARGV[2] = tsSeq, ARGV[3] = catalog.
 const removeDeltaScript = `
 local members = redis.call("ZRANGEBYSCORE", KEYS[1], ARGV[1], ARGV[1])
 for _, m in ipairs(members) do
   local ok, arr = pcall(cjson.decode, m)
   if ok and type(arr) == "table" and arr[3] == ARGV[2] then
     redis.call("ZREM", KEYS[1], m)
+    redis.call("HINCRBY", KEYS[2], ARGV[3] .. ":rg", 1)
     return 1
   end
 end
 return 0
 `
 
-// RemoveDelta deletes the delta index entry with the given tsSeq. The body
-// object in storage is untouched. Returns whether an entry was removed.
+// RemoveDelta deletes the delta index entry with the given tsSeq and bumps
+// the catalog's removal generation. The body object in storage is untouched.
+// Returns whether an entry was removed.
 func (w *Writer) RemoveDelta(ctx context.Context, catalog string, tsSeq TimeSeqID) (bool, error) {
 	res, err := w.rdb.Eval(ctx, removeDeltaScript,
-		[]string{w.MakeDeltaZsetKey(catalog)},
-		tsSeq.Score(), tsSeq.String(),
+		[]string{w.MakeDeltaZsetKey(catalog), w.MakeSnapsHashKey()},
+		tsSeq.Score(), tsSeq.String(), catalog,
 	).Result()
 	if err != nil {
 		return false, fmt.Errorf("remove delta eval: %w", err)

--- a/internal/index/writer_delta_test.go
+++ b/internal/index/writer_delta_test.go
@@ -1,0 +1,56 @@
+package index
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRemoveDelta pins the surgical-removal contract against live Redis:
+// exactly the entry with the given tsSeq goes away, neighbours at other
+// scores survive, and a second call (or a bogus tsSeq) removes nothing.
+func TestRemoveDelta(t *testing.T) {
+	rdb, prefix := indexTestRedis(t)
+	w := NewWriter(rdb)
+	r := NewReader(rdb)
+	w.SetPrefix(prefix)
+	r.SetPrefix(prefix)
+
+	ctx := context.Background()
+	const catalog = "users"
+	const uri = "oss://bucket/4f3a/(users/abc.dat"
+
+	var stops []TimeSeqID
+	for i := 0; i < 3; i++ {
+		ts, _, err := w.Notify(ctx, catalog, "/", MergeTypeReplace, uri)
+		if err != nil {
+			t.Fatalf("Notify #%d: %v", i, err)
+		}
+		stops = append(stops, ts)
+	}
+
+	// Nonexistent tsSeq → false, nothing touched.
+	removed, err := w.RemoveDelta(ctx, catalog, TimeSeqID{Timestamp: stops[0].Timestamp + 1000, SeqID: 1})
+	if err != nil || removed {
+		t.Fatalf("bogus tsSeq: removed=%v err=%v, want false/nil", removed, err)
+	}
+
+	// Remove the middle entry.
+	removed, err = w.RemoveDelta(ctx, catalog, stops[1])
+	if err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v, want true/nil", removed, err)
+	}
+	// Second call: already gone.
+	removed, err = w.RemoveDelta(ctx, catalog, stops[1])
+	if err != nil || removed {
+		t.Fatalf("second RemoveDelta: removed=%v err=%v, want false/nil", removed, err)
+	}
+
+	// Neighbours survive, in order.
+	_, rr := r.ListCatalog(ctx, catalog)
+	if rr.Err != nil {
+		t.Fatalf("ListCatalog: %v", rr.Err)
+	}
+	if len(rr.Deltas) != 2 || rr.Deltas[0].TsSeq != stops[0] || rr.Deltas[1].TsSeq != stops[2] {
+		t.Fatalf("survivors = %+v, want [%v %v]", rr.Deltas, stops[0], stops[2])
+	}
+}

--- a/internal/index/writer_delta_test.go
+++ b/internal/index/writer_delta_test.go
@@ -57,6 +57,27 @@ func TestRemoveDelta(t *testing.T) {
 	if rr.RemoveGen != "1" {
 		t.Fatalf("RemoveGen = %q, want \"1\" (exactly one successful removal)", rr.RemoveGen)
 	}
+
+	// Bump-before-delete: if the generation cannot advance (hand-corrupted
+	// non-integer ":rg"), the removal must fail with the delta INTACT — the
+	// reverse order would leave it gone under an unmoved generation, and an
+	// in-flight old-generation snapshot could resurrect it.
+	if err := rdb.HSet(ctx, w.MakeSnapsHashKey(), catalog+":rg", "corrupt").Err(); err != nil {
+		t.Fatalf("HSet corrupt rg: %v", err)
+	}
+	if _, err := w.RemoveDelta(ctx, catalog, stops[0]); err == nil {
+		t.Fatal("RemoveDelta with corrupt rg must error")
+	}
+	if card := rdb.ZCard(ctx, w.MakeDeltaZsetKey(catalog)).Val(); card != 2 {
+		t.Fatalf("delta removed despite failed generation bump: %d entries, want 2", card)
+	}
+	// Healing the field lets the removal proceed.
+	if err := rdb.HSet(ctx, w.MakeSnapsHashKey(), catalog+":rg", "1").Err(); err != nil {
+		t.Fatalf("heal rg: %v", err)
+	}
+	if removed, err := w.RemoveDelta(ctx, catalog, stops[0]); err != nil || !removed {
+		t.Fatalf("RemoveDelta after heal: removed=%v err=%v", removed, err)
+	}
 }
 
 // TestAddSnapRemoveGenBarrier pins the snapshot-resurrection guard: a

--- a/internal/index/writer_delta_test.go
+++ b/internal/index/writer_delta_test.go
@@ -45,12 +45,65 @@ func TestRemoveDelta(t *testing.T) {
 		t.Fatalf("second RemoveDelta: removed=%v err=%v, want false/nil", removed, err)
 	}
 
-	// Neighbours survive, in order.
+	// Neighbours survive, in order — and the removal generation moved from
+	// "0" to "1" (one successful removal; the failed attempts must not bump).
 	_, rr := r.ListCatalog(ctx, catalog)
 	if rr.Err != nil {
 		t.Fatalf("ListCatalog: %v", rr.Err)
 	}
 	if len(rr.Deltas) != 2 || rr.Deltas[0].TsSeq != stops[0] || rr.Deltas[1].TsSeq != stops[2] {
 		t.Fatalf("survivors = %+v, want [%v %v]", rr.Deltas, stops[0], stops[2])
+	}
+	if rr.RemoveGen != "1" {
+		t.Fatalf("RemoveGen = %q, want \"1\" (exactly one successful removal)", rr.RemoveGen)
+	}
+}
+
+// TestAddSnapRemoveGenBarrier pins the snapshot-resurrection guard: a
+// snapshot computed from a read that predates a RemoveDelta carries the old
+// generation and must be dropped; a snapshot from a post-removal read (new
+// generation) lands normally.
+func TestAddSnapRemoveGenBarrier(t *testing.T) {
+	rdb, prefix := indexTestRedis(t)
+	w := NewWriter(rdb)
+	r := NewReader(rdb)
+	w.SetPrefix(prefix)
+	r.SetPrefix(prefix)
+
+	ctx := context.Background()
+	const catalog = "users"
+	ts, _, err := w.Notify(ctx, catalog, "/", MergeTypeReplace, "oss://b/x.dat")
+	if err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+
+	// A reader lists the catalog (gen "0"), then the delta is removed.
+	_, rr := r.ListCatalog(ctx, catalog)
+	if rr.Err != nil || rr.RemoveGen != "0" {
+		t.Fatalf("pre-removal list: gen=%q err=%v, want \"0\"/nil", rr.RemoveGen, rr.Err)
+	}
+	if removed, err := w.RemoveDelta(ctx, catalog, ts); err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v", removed, err)
+	}
+
+	// The reader's snapshot (baking in the removed delta) must be refused.
+	if err := w.AddSnap(ctx, catalog, ts, "oss://b/stale.snap", rr.RemoveGen); err != nil {
+		t.Fatalf("AddSnap stale gen: %v", err)
+	}
+	if got, _ := r.GetLatestSnap(ctx, catalog); got != nil {
+		t.Fatalf("stale-generation snapshot landed: %+v — removed delta resurrected", got)
+	}
+
+	// A snapshot from a post-removal read (current gen) lands normally.
+	_, rr = r.ListCatalog(ctx, catalog)
+	if rr.Err != nil || rr.RemoveGen != "1" {
+		t.Fatalf("post-removal list: gen=%q err=%v, want \"1\"/nil", rr.RemoveGen, rr.Err)
+	}
+	if err := w.AddSnap(ctx, catalog, ts, "oss://b/fresh.snap", rr.RemoveGen); err != nil {
+		t.Fatalf("AddSnap fresh gen: %v", err)
+	}
+	got, err := r.GetLatestSnap(ctx, catalog)
+	if err != nil || got == nil || got.URI != "oss://b/fresh.snap" {
+		t.Fatalf("fresh-generation snapshot missing: got=%+v err=%v", got, err)
 	}
 }

--- a/internal/index/writer_snap.go
+++ b/internal/index/writer_snap.go
@@ -19,13 +19,23 @@ func NewWriter(rdb *redis.Client) *Writer {
 }
 
 // addSnapScript upserts the catalog's snap entry only when the new stop is
-// strictly newer than the stored one. Snapshot saves are async and may race
-// across processes: without the guard, a slow save computed at an older stop
-// could land after a newer one and regress the snap pointer (correct but
-// wasteful — every read replays more deltas until it heals). A stored value
-// snap_score rejects (see snapScoreLua, encoding.go) is treated as absent and
-// overwritten (self-heal). Returns 1 when the entry was written, 0 when the
-// stored snap was kept.
+// strictly newer than the stored one AND the snapshot was computed from the
+// catalog's current removal generation.
+//
+// Monotonicity: snapshot saves are async and may race across processes;
+// without the guard, a slow save computed at an older stop could land after
+// a newer one and regress the snap pointer (correct but wasteful). A stored
+// value snap_score rejects (see snapScoreLua, encoding.go) is treated as
+// absent and overwritten (self-heal).
+//
+// Removal barrier: a snapshot bakes in every delta the read listed. If a
+// RemoveDelta interleaved between that read and this save, the snapshot
+// would resurrect the removed write — permanently, since later reads prefer
+// the snap pointer. RemoveDelta bumps "<catalog>:rg"; a save whose
+// generation (captured atomically by listScript) no longer matches is
+// dropped. The next read starts from post-removal state and snapshots fine.
+//
+// Returns 1 when the entry was written, 0 when it was dropped/kept.
 const addSnapScript = snapScoreLua + `
 local cur = redis.call("HGET", KEYS[1], ARGV[1])
 if cur then
@@ -34,22 +44,29 @@ if cur then
     return 0
   end
 end
+if (redis.call("HGET", KEYS[1], ARGV[1] .. ":rg") or "0") ~= ARGV[4] then
+  return 0
+end
 redis.call("HSET", KEYS[1], ARGV[1], ARGV[2])
 return 1
 `
 
 // AddSnap upserts the catalog's snap entry in "<prefix>:s" as [tsSeq, uri],
-// but only monotonically: an entry at or past stopTsSeq is kept and the call
-// is a silent no-op (the freshly written snap object is left orphan in
-// storage, like any superseded snap — V3 contract).
-func (w *Writer) AddSnap(ctx context.Context, catalog string, stopTsSeq TimeSeqID, uri string) error {
+// but only monotonically, and only when removeGen still matches the
+// catalog's removal generation (see addSnapScript). Refusals are silent
+// no-ops; the freshly written snap object is left orphan in storage, like
+// any superseded snap — V3 contract.
+func (w *Writer) AddSnap(ctx context.Context, catalog string, stopTsSeq TimeSeqID, uri, removeGen string) error {
 	val, err := EncodeSnapValue(stopTsSeq, uri)
 	if err != nil {
 		return err
 	}
+	if removeGen == "" {
+		removeGen = "0"
+	}
 	return w.rdb.Eval(ctx, addSnapScript,
 		[]string{w.MakeSnapsHashKey()},
-		catalog, val, stopTsSeq.Score(),
+		catalog, val, stopTsSeq.Score(), removeGen,
 	).Err()
 }
 

--- a/internal/merge/engine.go
+++ b/internal/merge/engine.go
@@ -36,8 +36,8 @@ func Merge(baseData []byte, entries []index.DeltaInfo) ([]byte, error) {
 		merged, err = merger.Merge(merged, entry.Body, ToGjsonPath(entry.Path))
 		if err != nil {
 			// Identify the exact offending delta: a single unappliable patch
-			// fails every read of the catalog, so operators need its tsSeq /
-			// uri to locate and remove it.
+			// fails every read of the catalog, and the tsSeq printed here is
+			// precisely what Client.RemoveDelta takes to clear it.
 			return nil, fmt.Errorf("merge failed (path=%s tsSeq=%s uri=%s type=%d): %w",
 				entry.Path, entry.TsSeq, entry.URI, entry.MergeType, err)
 		}

--- a/lake.go
+++ b/lake.go
@@ -112,9 +112,11 @@ func WithSampleCacheRedis(rdb *redis.Client) func(*option) {
 // rejects any handle whose signature is missing or does not match — so a
 // handle that round-tripped through an untrusted client provably carries
 // exactly the Catalog/Path/MergeType/UUID/URI/ExpiresAt that WriteBegin
-// issued. (Without a secret, notify still enforces the structural
-// URI↔catalog/uuid binding; the secret additionally pins Path, MergeType and
-// ExpiresAt.) Every process sharing the prefix must be given the same secret.
+// issued — and, because ExpiresAt is then trustworthy, WriteNotify also
+// rejects handles past it (no indefinite replay of a leaked handle).
+// (Without a secret, notify still enforces the structural URI↔catalog/uuid
+// binding; the secret additionally pins Path, MergeType and ExpiresAt.)
+// Every process sharing the prefix must be given the same secret.
 // Panics on an empty secret (programmer error at construction time).
 func WithHandleSecret(secret []byte) func(*option) {
 	if len(secret) == 0 {

--- a/lake.go
+++ b/lake.go
@@ -38,6 +38,8 @@ type Client struct {
 	snapFlight   xsync.SingleFlight[string] // dedupe concurrent snapshot saves on (catalog, stop)
 	sampleFlight xsync.SingleFlight[string] // dedupe concurrent Sampler[T] loaders on (catalog, indicator, score)
 
+	handleSecret []byte // WithHandleSecret; empty disables handle signing
+
 	eventHandlers []EventHandler
 }
 
@@ -45,6 +47,7 @@ type option struct {
 	sampleRdb    *redis.Client
 	snapProvider string
 	snapBucket   string
+	handleSecret []byte
 }
 
 // New creates a Lake client.
@@ -80,6 +83,7 @@ func New(prefix string, rdb *redis.Client, resolve storage.Resolver, opts ...fun
 		resolve:      resolve,
 		snapProvider: o.snapProvider,
 		snapBucket:   o.snapBucket,
+		handleSecret: o.handleSecret,
 		stores:       make(map[string]storage.Storage),
 		snapFlight:   xsync.NewSingleFlight[string](),
 		sampleFlight: xsync.NewSingleFlight[string](),
@@ -101,6 +105,22 @@ func WithSnapTarget(provider, bucket string) func(*option) {
 // separate Redis instance. Defaults to the authoritative rdb.
 func WithSampleCacheRedis(rdb *redis.Client) func(*option) {
 	return func(o *option) { o.sampleRdb = rdb }
+}
+
+// WithHandleSecret turns on WriteHandle signing. WriteBegin stamps every
+// handle with an HMAC-SHA256 over its identity fields, and WriteNotify
+// rejects any handle whose signature is missing or does not match — so a
+// handle that round-tripped through an untrusted client provably carries
+// exactly the Catalog/Path/MergeType/UUID/URI/ExpiresAt that WriteBegin
+// issued. (Without a secret, notify still enforces the structural
+// URI↔catalog/uuid binding; the secret additionally pins Path, MergeType and
+// ExpiresAt.) Every process sharing the prefix must be given the same secret.
+// Panics on an empty secret (programmer error at construction time).
+func WithHandleSecret(secret []byte) func(*option) {
+	if len(secret) == 0 {
+		panic("lake: WithHandleSecret requires a non-empty secret")
+	}
+	return func(o *option) { o.handleSecret = append([]byte(nil), secret...) }
 }
 
 // WithSampleCacheURL is the URL form of WithSampleCacheRedis. Panics on an

--- a/list.go
+++ b/list.go
@@ -36,6 +36,19 @@ func (m ListResult) Exist() bool {
 	return m.LatestSnap != nil || len(m.Entries) > 0
 }
 
+// RemoveGen is the catalog's removal generation observed atomically with
+// this list ("0" until the first RemoveDelta). Cross-catalog Samplers use it
+// the same way they use LastUpdated: record the peer generations the sample
+// depended on inside T, and have a WithShouldRefresh predicate compare them
+// against peers[...].RemoveGen() — a removal on a peer can lower or preserve
+// that peer's LastUpdated, so the version alone cannot reveal it.
+func (m ListResult) RemoveGen() string {
+	if m.removeGen == "" {
+		return "0"
+	}
+	return m.removeGen
+}
+
 func (m ListResult) HasNextSnap() bool { return len(m.Entries) > 0 }
 
 // NextSnap is the snap that should next be persisted, or nil if there

--- a/list.go
+++ b/list.go
@@ -14,6 +14,7 @@ import (
 type ListResult struct {
 	client     *Client
 	catalog    string
+	removeGen  string // removal generation at list time; guards snapshot saves
 	LatestSnap *index.SnapInfo
 	Entries    []index.DeltaInfo
 	Err        error
@@ -87,6 +88,7 @@ func (c *Client) List(ctx context.Context, catalog string) *ListResult {
 	return &ListResult{
 		client:     c,
 		catalog:    catalog,
+		removeGen:  rr.RemoveGen,
 		LatestSnap: snap,
 		Entries:    rr.Deltas,
 		Err:        rr.Err,
@@ -119,6 +121,7 @@ func (c *Client) BatchList(ctx context.Context, catalogs []string) map[string]*L
 			lr.LatestSnap = br.Snap
 			if br.ReadResult != nil {
 				lr.Entries = br.ReadResult.Deltas
+				lr.removeGen = br.ReadResult.RemoveGen
 			}
 		}
 		out[cat] = lr

--- a/poison_body_test.go
+++ b/poison_body_test.go
@@ -61,4 +61,21 @@ func TestPoisonBodyFailsLoudly_Redis(t *testing.T) {
 	if snap, _ := c.reader.GetLatestSnap(ctx, "users"); snap != nil {
 		t.Fatalf("a failed read must not persist a snapshot, got %+v", snap)
 	}
+
+	// Recovery: RemoveDelta with the tsSeq the merge error names clears the
+	// poison entry, and the catalog reads again.
+	removed, err := c.RemoveDelta(ctx, "users", list.Entries[0].TsSeq.String())
+	if err != nil {
+		t.Fatalf("RemoveDelta: %v", err)
+	}
+	if !removed {
+		t.Fatal("RemoveDelta reported nothing removed")
+	}
+	got, err := ReadString(ctx, c.List(ctx, "users"))
+	if err != nil {
+		t.Fatalf("read after RemoveDelta: %v", err)
+	}
+	if got != "{}" {
+		t.Fatalf("read after RemoveDelta = %q, want empty document", got)
+	}
 }

--- a/read.go
+++ b/read.go
@@ -57,7 +57,7 @@ func (c *Client) readData(ctx context.Context, list *ListResult) ([]byte, error)
 	if c.snapProvider != "" {
 		if next := list.NextSnap(); next != nil {
 			snapData := append([]byte(nil), resultData...)
-			go c.saveSnapshot(context.Background(), list.catalog, next.StopTsSeq, snapData)
+			go c.saveSnapshot(context.Background(), list.catalog, next.StopTsSeq, list.removeGen, snapData)
 		}
 	}
 	return resultData, nil

--- a/remove.go
+++ b/remove.go
@@ -2,6 +2,7 @@ package lake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hkloudou/lake/v3/internal/index"
 	"github.com/hkloudou/lake/v3/internal/utils"
@@ -15,15 +16,27 @@ import (
 //	merge failed (path=/profile tsSeq=1700000000_42 uri=... type=1): ...
 //	→ removed, err := client.RemoveDelta(ctx, "users", "1700000000_42")
 //
-// tsSeq is that "{timestamp}_{seqid}" string, verbatim. Only the Redis index
-// entry is removed — the body object in storage is untouched. Returns whether
-// an entry was actually removed (false: no delta at that tsSeq, e.g. already
-// removed or compacted).
+// tsSeq is that "{timestamp}_{seqid}" string, verbatim. Only Redis state is
+// touched — the body object in storage remains. Returns whether an entry was
+// actually removed (false: no delta at that tsSeq, e.g. already removed or
+// compacted).
 //
-// DESTRUCTIVE: the removed delta's write is dropped from every future read
-// (past snapshots that already absorbed it are unaffected). This is the
-// point — the delta was blocking the catalog — but it is not an undo for
-// healthy writes.
+// Removal is coherent with derived state:
+//
+//   - snapshots: the removal bumps the catalog's removal generation in the
+//     same atomic step, and AddSnap refuses a snapshot computed from an
+//     earlier generation — so a read that was in flight (and had listed the
+//     removed delta) cannot persist its effect. Snapshots that ALREADY
+//     absorbed the delta before this call keep it — RemoveDelta unblocks the
+//     log, it does not rewrite history.
+//   - samples: every indicator's memo entry for the catalog is invalidated
+//     (epoch-bumped, so in-flight sample computes cannot write stale values
+//     back either). On sweep failure the delta is still removed; the error
+//     tells the operator to retry InvalidateSamples per indicator.
+//
+// DESTRUCTIVE: the removed delta's write disappears from every future read.
+// That is the point — the delta was blocking the catalog — but it is not an
+// undo mechanism for healthy writes.
 func (c *Client) RemoveDelta(ctx context.Context, catalog, tsSeq string) (bool, error) {
 	c.emitEvent(catalog, "RemoveDelta", map[string]any{"tsSeq": tsSeq})
 	if err := utils.ValidateCatalog(catalog); err != nil {
@@ -33,5 +46,37 @@ func (c *Client) RemoveDelta(ctx context.Context, catalog, tsSeq string) (bool, 
 	if err != nil {
 		return false, err
 	}
-	return c.writer.RemoveDelta(ctx, catalog, id)
+	removed, err := c.writer.RemoveDelta(ctx, catalog, id)
+	if err != nil || !removed {
+		return removed, err
+	}
+	if err := c.invalidateAllSamples(ctx, catalog); err != nil {
+		return true, fmt.Errorf("delta removed, but sample invalidation failed (retry InvalidateSamples per indicator): %w", err)
+	}
+	return true, nil
+}
+
+// invalidateAllSamples sweeps every indicator's memo hash ("<prefix>:m:*" on
+// the sample Redis) and invalidates the catalog's entry in each — the same
+// epoch-bump + delete InvalidateSamples performs, so in-flight computes for
+// any indicator cannot reinstate a value derived from the removed delta.
+// SCAN-based: never blocks the server on the full keyspace.
+func (c *Client) invalidateAllSamples(ctx context.Context, catalog string) error {
+	pattern := c.reader.Prefix() + ":m:*"
+	var cursor uint64
+	for {
+		keys, next, err := c.sampleRdb.Scan(ctx, cursor, pattern, 256).Result()
+		if err != nil {
+			return err
+		}
+		for _, key := range keys {
+			if err := c.sampleRdb.Eval(ctx, sampleInvalidateScript, []string{key}, catalog).Err(); err != nil {
+				return fmt.Errorf("invalidate %s: %w", key, err)
+			}
+		}
+		if next == 0 {
+			return nil
+		}
+		cursor = next
+	}
 }

--- a/remove.go
+++ b/remove.go
@@ -3,6 +3,7 @@ package lake
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hkloudou/lake/v3/internal/index"
 	"github.com/hkloudou/lake/v3/internal/utils"
@@ -72,7 +73,10 @@ func (c *Client) invalidateAllSamples(ctx context.Context, catalog string) error
 	if err := c.sampleRdb.HIncrBy(ctx, c.reader.MakeSampleRemoveGenKey(), catalog, 1).Err(); err != nil {
 		return fmt.Errorf("bump sample removal gen: %w", err)
 	}
-	pattern := c.reader.Prefix() + ":m:*"
+	// The prefix is user-supplied and MATCH treats *?[]\ as glob syntax —
+	// unescaped, a prefix like "app[1]" would silently match the wrong keys
+	// (missing this deployment's memo hashes, or sweeping another's).
+	pattern := globEscape(c.reader.Prefix()) + ":m:*"
 	var cursor uint64
 	for {
 		keys, next, err := c.sampleRdb.Scan(ctx, cursor, pattern, 256).Result()
@@ -89,4 +93,19 @@ func (c *Client) invalidateAllSamples(ctx context.Context, catalog string) error
 		}
 		cursor = next
 	}
+}
+
+// globEscape backslash-escapes Redis MATCH metacharacters so s matches only
+// itself as a literal pattern segment.
+func globEscape(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '*', '?', '[', ']', '\\':
+			b.WriteByte('\\')
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
 }

--- a/remove.go
+++ b/remove.go
@@ -30,10 +30,13 @@ import (
 //     removed delta) cannot persist its effect. Snapshots that ALREADY
 //     absorbed the delta before this call keep it — RemoveDelta unblocks the
 //     log, it does not rewrite history.
-//   - samples: every indicator's memo entry for the catalog is invalidated
-//     (epoch-bumped, so in-flight sample computes cannot write stale values
-//     back either). On sweep failure the delta is still removed; the error
-//     tells the operator to retry InvalidateSamples per indicator.
+//   - samples: the catalog's sample removal generation is bumped BEFORE the
+//     removal (in-flight computes for any indicator — even one that has
+//     never cached — cannot write pre-removal state back), cached entries
+//     carry the generation they were computed under and are rejected on
+//     generation mismatch at read time, and every indicator's memo entry is
+//     swept eagerly. A sweep failure therefore costs memory, not
+//     correctness.
 //
 // DESTRUCTIVE: the removed delta's write disappears from every future read.
 // That is the point — the delta was blocking the catalog — but it is not an
@@ -47,32 +50,37 @@ func (c *Client) RemoveDelta(ctx context.Context, catalog, tsSeq string) (bool, 
 	if err != nil {
 		return false, err
 	}
+	// Install the sample write barrier BEFORE removing anything: if the bump
+	// failed after the ZREM (e.g. a separate sample-cache Redis briefly
+	// down), the delta would be gone with the barrier at the old generation,
+	// an in-flight first-ever sampler could still cache pre-removal state,
+	// and a retry would return false without ever installing the barrier. A
+	// bump whose removal then fails is harmless — it only discards some
+	// in-flight cache writes.
+	if err := c.sampleRdb.HIncrBy(ctx, c.reader.MakeSampleRemoveGenKey(), catalog, 1).Err(); err != nil {
+		return false, fmt.Errorf("install sample barrier: %w", err)
+	}
 	removed, err := c.writer.RemoveDelta(ctx, catalog, id)
 	if err != nil || !removed {
 		return removed, err
 	}
-	if err := c.invalidateAllSamples(ctx, catalog); err != nil {
-		return true, fmt.Errorf("delta removed, but sample invalidation failed (retry InvalidateSamples per indicator): %w", err)
+	if err := c.sweepSamples(ctx, catalog); err != nil {
+		// Correctness no longer depends on the sweep (stale entries carry an
+		// older generation and are rejected at read time); failing here only
+		// leaves memory to reclaim.
+		return true, fmt.Errorf("delta removed, but memo sweep failed (entries expire from reads; retry InvalidateSamples to reclaim now): %w", err)
 	}
 	return true, nil
 }
 
-// invalidateAllSamples voids the catalog's sample state across ALL
-// indicators after a removal, in two steps whose order matters:
-//
-//  1. Bump the catalog's removal generation ("<prefix>:mrg"). Every memo
-//     write is conditional on the generation it observed at probe time, so
-//     this instantly voids in-flight computes for every indicator —
-//     including one whose memo hash does not exist yet (a first-ever Sample
-//     racing the removal), which no key scan could reach.
-//  2. Delete the catalog's entry from every EXISTING memo hash (SCAN
-//     "<prefix>:m:*"; never blocks the server on the full keyspace).
-//     Necessary because a removal can lower LastUpdated(), so the staleness
-//     floor would keep serving an already-cached entry forever.
-func (c *Client) invalidateAllSamples(ctx context.Context, catalog string) error {
-	if err := c.sampleRdb.HIncrBy(ctx, c.reader.MakeSampleRemoveGenKey(), catalog, 1).Err(); err != nil {
-		return fmt.Errorf("bump sample removal gen: %w", err)
-	}
+// sweepSamples deletes the catalog's entry from every EXISTING memo hash
+// (SCAN "<prefix>:m:*"; never blocks the server on the full keyspace). The
+// write barrier ("<prefix>:mrg", bumped by RemoveDelta before the removal)
+// already voids in-flight computes for every indicator — including ones
+// whose memo hash does not exist yet, which no key scan could reach — and
+// the per-entry generation check rejects unswept entries at read time; this
+// sweep just reclaims their memory eagerly.
+func (c *Client) sweepSamples(ctx context.Context, catalog string) error {
 	// The prefix is user-supplied and MATCH treats *?[]\ as glob syntax —
 	// unescaped, a prefix like "app[1]" would silently match the wrong keys
 	// (missing this deployment's memo hashes, or sweeping another's).

--- a/remove.go
+++ b/remove.go
@@ -1,0 +1,37 @@
+package lake
+
+import (
+	"context"
+
+	"github.com/hkloudou/lake/v3/internal/index"
+	"github.com/hkloudou/lake/v3/internal/utils"
+)
+
+// RemoveDelta is the operator's escape hatch for a poison delta — one whose
+// body cannot be merged (invalid JSON, unappliable patch) and therefore
+// fails EVERY read of the catalog. The merge error names the offending
+// delta's tsSeq exactly for this call:
+//
+//	merge failed (path=/profile tsSeq=1700000000_42 uri=... type=1): ...
+//	→ removed, err := client.RemoveDelta(ctx, "users", "1700000000_42")
+//
+// tsSeq is that "{timestamp}_{seqid}" string, verbatim. Only the Redis index
+// entry is removed — the body object in storage is untouched. Returns whether
+// an entry was actually removed (false: no delta at that tsSeq, e.g. already
+// removed or compacted).
+//
+// DESTRUCTIVE: the removed delta's write is dropped from every future read
+// (past snapshots that already absorbed it are unaffected). This is the
+// point — the delta was blocking the catalog — but it is not an undo for
+// healthy writes.
+func (c *Client) RemoveDelta(ctx context.Context, catalog, tsSeq string) (bool, error) {
+	c.emitEvent(catalog, "RemoveDelta", map[string]any{"tsSeq": tsSeq})
+	if err := utils.ValidateCatalog(catalog); err != nil {
+		return false, err
+	}
+	id, err := index.ParseTimeSeqID(tsSeq)
+	if err != nil {
+		return false, err
+	}
+	return c.writer.RemoveDelta(ctx, catalog, id)
+}

--- a/remove.go
+++ b/remove.go
@@ -56,12 +56,22 @@ func (c *Client) RemoveDelta(ctx context.Context, catalog, tsSeq string) (bool, 
 	return true, nil
 }
 
-// invalidateAllSamples sweeps every indicator's memo hash ("<prefix>:m:*" on
-// the sample Redis) and invalidates the catalog's entry in each — the same
-// epoch-bump + delete InvalidateSamples performs, so in-flight computes for
-// any indicator cannot reinstate a value derived from the removed delta.
-// SCAN-based: never blocks the server on the full keyspace.
+// invalidateAllSamples voids the catalog's sample state across ALL
+// indicators after a removal, in two steps whose order matters:
+//
+//  1. Bump the catalog's removal generation ("<prefix>:mrg"). Every memo
+//     write is conditional on the generation it observed at probe time, so
+//     this instantly voids in-flight computes for every indicator —
+//     including one whose memo hash does not exist yet (a first-ever Sample
+//     racing the removal), which no key scan could reach.
+//  2. Delete the catalog's entry from every EXISTING memo hash (SCAN
+//     "<prefix>:m:*"; never blocks the server on the full keyspace).
+//     Necessary because a removal can lower LastUpdated(), so the staleness
+//     floor would keep serving an already-cached entry forever.
 func (c *Client) invalidateAllSamples(ctx context.Context, catalog string) error {
+	if err := c.sampleRdb.HIncrBy(ctx, c.reader.MakeSampleRemoveGenKey(), catalog, 1).Err(); err != nil {
+		return fmt.Errorf("bump sample removal gen: %w", err)
+	}
 	pattern := c.reader.Prefix() + ":m:*"
 	var cursor uint64
 	for {
@@ -70,7 +80,7 @@ func (c *Client) invalidateAllSamples(ctx context.Context, catalog string) error
 			return err
 		}
 		for _, key := range keys {
-			if err := c.sampleRdb.Eval(ctx, sampleInvalidateScript, []string{key}, catalog).Err(); err != nil {
+			if err := c.sampleRdb.HDel(ctx, key, catalog).Err(); err != nil {
 				return fmt.Errorf("invalidate %s: %w", key, err)
 			}
 		}

--- a/sample.go
+++ b/sample.go
@@ -268,6 +268,34 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 	return out
 }
 
+// InvalidateSamples deletes the cached samples of one indicator for the given
+// catalogs (one HDEL on the memo hash) and returns how many entries existed.
+// The next Sample/Batch recomputes them.
+//
+// The memo hash has no TTL of its own, so this is the hook for the two cases
+// staleness policies cannot see: a catalog that was deleted outright (its
+// memo field would otherwise linger forever), and a loader whose CODE changed
+// (the data version didn't move, but the cached value is now computed wrong).
+// Works on any Client with the same prefix — no Sampler[T] value needed, so
+// ops tooling can sweep without knowing T.
+func (c *Client) InvalidateSamples(ctx context.Context, indicator string, catalogs ...string) (int64, error) {
+	for _, cat := range catalogs {
+		c.emitEvent(cat, "InvalidateSample", map[string]any{"indicator": indicator})
+	}
+	if err := utils.ValidateCatalog(indicator); err != nil {
+		return 0, fmt.Errorf("invalid indicator: %w", err)
+	}
+	for _, cat := range catalogs {
+		if err := utils.ValidateCatalog(cat); err != nil {
+			return 0, err
+		}
+	}
+	if len(catalogs) == 0 {
+		return 0, nil
+	}
+	return c.sampleRdb.HDel(ctx, c.reader.MakeSampleIndicatorKey(indicator), catalogs...).Result()
+}
+
 // isStale decides whether a cached entry must be recomputed. The data-
 // version floor is mandatory; maxAge and shouldRefresh only ADD triggers
 // (they can force a refresh, never suppress one the data version requires).

--- a/sample.go
+++ b/sample.go
@@ -119,9 +119,11 @@ func WithMaxAge[T any](d time.Duration) SamplerOption[T] {
 // so it MUST be pure and cheap: do no I/O.
 //
 // To act on a cross-catalog dependency, fan out a single BatchList covering
-// the catalogs you care about, then compare peers["B"].LastUpdated() against
-// whatever version of B the cached T recorded at compute time (T is the
-// natural place to carry "what I depended on" — Sampler does not track it).
+// the catalogs you care about, then compare peers["B"].LastUpdated() — and
+// peers["B"].RemoveGen(), since a RemoveDelta on B can lower or preserve
+// B's version — against whatever baseline the cached T recorded at compute
+// time (T is the natural place to carry "what I depended on" — Sampler does
+// not track it, and its own generation check covers only self's catalog).
 // If the relevant peer is absent from peers, the dependency cannot be
 // evaluated this call; either return false (accept the stale value this
 // time) or arrange for BatchList to include it next time.

--- a/sample.go
+++ b/sample.go
@@ -211,21 +211,29 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 	now := c.reader.NowUnix()
 	hashKey := c.reader.MakeSampleIndicatorKey(s.indicator)
 
-	cached, err := c.sampleRdb.HMGet(ctx, hashKey, probe...).Result()
+	// One HMGet probes every catalog's cached value plus the epoch field —
+	// captured before any loader runs, so a mid-batch invalidation voids the
+	// batch's write-backs.
+	fields := append(append(make([]string, 0, len(probe)+1), probe...), sampleEpochField)
+	epoch := "0"
+	cached, err := c.sampleRdb.HMGet(ctx, hashKey, fields...).Result()
 	if err != nil && err != redis.Nil {
 		// Cache-read failure: degrade to recompute-all rather than fail
 		// the batch (the cache is an optimization, not the truth).
 		for _, cat := range probe {
 			c.emitEvent(cat, "SampleCacheError", map[string]any{"op": "hmget", "err": err.Error()})
 		}
-		cached = make([]any, len(probe))
+		cached = make([]any, len(fields))
+	}
+	if e, ok := cached[len(probe)].(string); ok {
+		epoch = e
 	}
 
 	var (
 		mu     sync.Mutex
 		misses []string
 	)
-	for i, raw := range cached {
+	for i, raw := range cached[:len(probe)] {
 		cat := probe[i]
 		l := lists[cat]
 		if str, ok := raw.(string); ok {
@@ -253,7 +261,7 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 				// Re-read the clock per loader run: with many misses ahead in
 				// the queue, the batch-start `now` could stamp an UpdatedAt
 				// already a whole maxAge in the past.
-				v, e := s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), c.reader.NowUnix()))
+				v, e := s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), c.reader.NowUnix(), epoch))
 				mu.Lock()
 				out[cat] = &SampleResult[T]{Value: v, Err: e}
 				mu.Unlock()
@@ -268,16 +276,47 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 	return out
 }
 
+// sampleEpochField is the memo hash's reserved epoch field. Catalog names
+// cannot be ":" (ValidateCatalog forbids the character entirely), so it can
+// never collide with a real catalog field. The epoch is bumped by every
+// invalidation; loadAndCache captures it at probe time and its write-back is
+// discarded if the epoch moved — otherwise an in-flight HSET landing after
+// an HDEL would silently reinstate the just-invalidated value, and with the
+// data version unchanged nothing would ever evict it again.
+const sampleEpochField = ":"
+
+// sampleWriteScript writes a computed sample only if the memo epoch still
+// matches what the writer observed before running its loader.
+// KEYS[1] = memo hash; ARGV[1] = epoch, ARGV[2] = catalog, ARGV[3] = value.
+const sampleWriteScript = `
+if (redis.call("HGET", KEYS[1], ":") or "0") == ARGV[1] then
+  redis.call("HSET", KEYS[1], ARGV[2], ARGV[3])
+  return 1
+end
+return 0
+`
+
+// sampleInvalidateScript bumps the epoch and deletes the catalogs' fields in
+// one atomic step. KEYS[1] = memo hash; ARGV = catalogs. Returns the number
+// of fields deleted.
+const sampleInvalidateScript = `
+redis.call("HINCRBY", KEYS[1], ":", 1)
+return redis.call("HDEL", KEYS[1], unpack(ARGV))
+`
+
 // InvalidateSamples deletes the cached samples of one indicator for the given
-// catalogs (one HDEL on the memo hash) and returns how many entries existed.
-// The next Sample/Batch recomputes them.
+// catalogs and returns how many entries existed. The next Sample/Batch
+// recomputes them. Deletion and the epoch bump are atomic, so a compute
+// already in flight when the invalidation lands cannot write its (stale)
+// result back — its epoch no longer matches (see sampleEpochField).
 //
 // The memo hash has no TTL of its own, so this is the hook for the two cases
 // staleness policies cannot see: a catalog that was deleted outright (its
 // memo field would otherwise linger forever), and a loader whose CODE changed
 // (the data version didn't move, but the cached value is now computed wrong).
 // Works on any Client with the same prefix — no Sampler[T] value needed, so
-// ops tooling can sweep without knowing T.
+// ops tooling can sweep without knowing T. RemoveDelta calls this for every
+// indicator automatically.
 func (c *Client) InvalidateSamples(ctx context.Context, indicator string, catalogs ...string) (int64, error) {
 	for _, cat := range catalogs {
 		c.emitEvent(cat, "InvalidateSample", map[string]any{"indicator": indicator})
@@ -293,7 +332,17 @@ func (c *Client) InvalidateSamples(ctx context.Context, indicator string, catalo
 	if len(catalogs) == 0 {
 		return 0, nil
 	}
-	return c.sampleRdb.HDel(ctx, c.reader.MakeSampleIndicatorKey(indicator), catalogs...).Result()
+	args := make([]any, len(catalogs))
+	for i, cat := range catalogs {
+		args[i] = cat
+	}
+	res, err := c.sampleRdb.Eval(ctx, sampleInvalidateScript,
+		[]string{c.reader.MakeSampleIndicatorKey(indicator)}, args...).Result()
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.(int64)
+	return n, nil
 }
 
 // isStale decides whether a cached entry must be recomputed. The data-
@@ -316,30 +365,42 @@ func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, peers map[string
 	return false
 }
 
-// sampleCore is the cache-or-compute path for a single catalog: one HGET,
-// then load on miss/stale. A cache-READ failure degrades to recompute — it
-// never fails the call.
+// sampleCore is the cache-or-compute path for a single catalog: one HMGET
+// (value + epoch), then load on miss/stale. A cache-READ failure degrades to
+// recompute — it never fails the call. The epoch is captured here, BEFORE the
+// loader runs, so an invalidation that lands during the compute makes the
+// write-back a no-op.
 func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult, peers map[string]*ListResult) (T, error) {
 	lastUpdated := list.LastUpdated()
 	now := c.reader.NowUnix()
 	hashKey := c.reader.MakeSampleIndicatorKey(s.indicator)
 
-	if cached, err := c.sampleRdb.HGet(ctx, hashKey, list.catalog).Bytes(); err == nil {
-		if meta, data, derr := unmarshalSampleCache[T](cached); derr == nil && !s.isStale(meta, list, peers, now) {
-			return data, nil
+	epoch := "0"
+	if vals, err := c.sampleRdb.HMGet(ctx, hashKey, list.catalog, sampleEpochField).Result(); err != nil {
+		c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hmget", "err": err.Error()})
+	} else {
+		if e, ok := vals[1].(string); ok {
+			epoch = e
 		}
-	} else if err != redis.Nil {
-		c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hget", "err": err.Error()})
+		if cached, ok := vals[0].(string); ok {
+			if meta, data, derr := unmarshalSampleCache[T]([]byte(cached)); derr == nil && !s.isStale(meta, list, peers, now) {
+				return data, nil
+			}
+		}
 	}
-	return s.loadAndCache(ctx, c, list, hashKey, lastUpdated, now)
+	return s.loadAndCache(ctx, c, list, hashKey, lastUpdated, now, epoch)
 }
 
 // loadAndCache runs the loader under the (catalog, indicator, version)
 // SingleFlight, stamps [score, updatedAt, data], and writes it back
-// best-effort. A loader error is wrapped (loaderError) so finalize can
-// distinguish it from an internal encode error; a cache-WRITE failure is
-// swallowed — the computed value is already correct and is returned anyway.
-func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResult, hashKey string, lastUpdated float64, now int64) (T, error) {
+// best-effort — and conditionally: the write lands only if the memo epoch
+// still matches what the caller observed before the loader ran, so an
+// invalidation cannot be undone by an in-flight compute (the value is still
+// returned to this caller; it just isn't cached). A loader error is wrapped
+// (loaderError) so finalize can distinguish it from an internal encode
+// error; a cache-WRITE failure is swallowed — the computed value is already
+// correct and is returned anyway.
+func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResult, hashKey string, lastUpdated float64, now int64, epoch string) (T, error) {
 	var zero T
 	flightKey := fmt.Sprintf("%s:%s:%.6f", list.catalog, s.indicator, lastUpdated)
 	raw, err := c.sampleFlight.Do(flightKey, func() (string, error) {
@@ -351,7 +412,7 @@ func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResu
 		if merr != nil {
 			return "", fmt.Errorf("marshal sample: %w", merr)
 		}
-		if werr := c.sampleRdb.HSet(ctx, hashKey, list.catalog, data).Err(); werr != nil {
+		if werr := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey}, epoch, list.catalog, data).Err(); werr != nil {
 			c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hset", "err": werr.Error()})
 		}
 		return string(data), nil

--- a/sample.go
+++ b/sample.go
@@ -211,12 +211,33 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 	now := c.reader.NowUnix()
 	hashKey := c.reader.MakeSampleIndicatorKey(s.indicator)
 
-	// One HMGet probes every catalog's cached value plus the epoch field —
-	// captured before any loader runs, so a mid-batch invalidation voids the
-	// batch's write-backs.
+	// One pipelined round-trip probes every catalog's cached value plus both
+	// write barriers (indicator epoch + per-catalog removal generation) —
+	// captured before any loader runs, so a mid-batch invalidation or
+	// removal voids the batch's write-backs.
 	fields := append(append(make([]string, 0, len(probe)+1), probe...), sampleEpochField)
 	epoch := "0"
-	cached, err := c.sampleRdb.HMGet(ctx, hashKey, fields...).Result()
+	pipe := c.sampleRdb.Pipeline()
+	memoCmd := pipe.HMGet(ctx, hashKey, fields...)
+	genCmd := pipe.HMGet(ctx, c.reader.MakeSampleRemoveGenKey(), probe...)
+	_, _ = pipe.Exec(ctx)
+
+	catGens := make(map[string]string, len(probe))
+	if genVals, err := genCmd.Result(); err == nil && len(genVals) == len(probe) {
+		for i, raw := range genVals {
+			if g, ok := raw.(string); ok {
+				catGens[probe[i]] = g
+			}
+		}
+	}
+	catGen := func(cat string) string {
+		if g, ok := catGens[cat]; ok {
+			return g
+		}
+		return "0"
+	}
+
+	cached, err := memoCmd.Result()
 	if err != nil && err != redis.Nil {
 		// Cache-read failure: degrade to recompute-all rather than fail
 		// the batch (the cache is an optimization, not the truth).
@@ -261,7 +282,7 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 				// Re-read the clock per loader run: with many misses ahead in
 				// the queue, the batch-start `now` could stamp an UpdatedAt
 				// already a whole maxAge in the past.
-				v, e := s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), c.reader.NowUnix(), epoch))
+				v, e := s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), c.reader.NowUnix(), epoch, catGen(cat)))
 				mu.Lock()
 				out[cat] = &SampleResult[T]{Value: v, Err: e}
 				mu.Unlock()
@@ -285,12 +306,19 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 // data version unchanged nothing would ever evict it again.
 const sampleEpochField = ":"
 
-// sampleWriteScript writes a computed sample only if the memo epoch still
-// matches what the writer observed before running its loader.
-// KEYS[1] = memo hash; ARGV[1] = epoch, ARGV[2] = catalog, ARGV[3] = value.
+// sampleWriteScript writes a computed sample only if BOTH barriers still
+// match what the writer observed before running its loader: the indicator's
+// memo epoch (bumped by InvalidateSamples) and the catalog's removal
+// generation in "<prefix>:mrg" (bumped by RemoveDelta — this one exists even
+// for an indicator that has never cached anything, which the memo epoch
+// alone cannot cover: a first-ever compute would see the missing epoch as
+// "0" and land a value derived from the removed delta).
+// KEYS[1] = memo hash, KEYS[2] = removal-gen hash; ARGV[1] = memo epoch,
+// ARGV[2] = catalog removal gen, ARGV[3] = catalog, ARGV[4] = value.
 const sampleWriteScript = `
-if (redis.call("HGET", KEYS[1], ":") or "0") == ARGV[1] then
-  redis.call("HSET", KEYS[1], ARGV[2], ARGV[3])
+if (redis.call("HGET", KEYS[1], ":") or "0") == ARGV[1]
+    and (redis.call("HGET", KEYS[2], ARGV[3]) or "0") == ARGV[2] then
+  redis.call("HSET", KEYS[1], ARGV[3], ARGV[4])
   return 1
 end
 return 0
@@ -365,18 +393,27 @@ func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, peers map[string
 	return false
 }
 
-// sampleCore is the cache-or-compute path for a single catalog: one HMGET
-// (value + epoch), then load on miss/stale. A cache-READ failure degrades to
-// recompute — it never fails the call. The epoch is captured here, BEFORE the
-// loader runs, so an invalidation that lands during the compute makes the
-// write-back a no-op.
+// sampleCore is the cache-or-compute path for a single catalog: one
+// pipelined round-trip probing the cached value plus both write barriers,
+// then load on miss/stale. A cache-READ failure degrades to recompute — it
+// never fails the call. Both barriers are captured here, BEFORE the loader
+// runs, so an invalidation or removal that lands during the compute makes
+// the write-back a no-op. An unreadable barrier stays "0", which can only
+// DISCARD the write — never admit a stale one.
 func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult, peers map[string]*ListResult) (T, error) {
 	lastUpdated := list.LastUpdated()
 	now := c.reader.NowUnix()
 	hashKey := c.reader.MakeSampleIndicatorKey(s.indicator)
 
-	epoch := "0"
-	if vals, err := c.sampleRdb.HMGet(ctx, hashKey, list.catalog, sampleEpochField).Result(); err != nil {
+	epoch, catGen := "0", "0"
+	pipe := c.sampleRdb.Pipeline()
+	memoCmd := pipe.HMGet(ctx, hashKey, list.catalog, sampleEpochField)
+	genCmd := pipe.HGet(ctx, c.reader.MakeSampleRemoveGenKey(), list.catalog)
+	_, _ = pipe.Exec(ctx)
+	if g, err := genCmd.Result(); err == nil {
+		catGen = g
+	}
+	if vals, err := memoCmd.Result(); err != nil {
 		c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hmget", "err": err.Error()})
 	} else {
 		if e, ok := vals[1].(string); ok {
@@ -388,21 +425,29 @@ func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult
 			}
 		}
 	}
-	return s.loadAndCache(ctx, c, list, hashKey, lastUpdated, now, epoch)
+	return s.loadAndCache(ctx, c, list, hashKey, lastUpdated, now, epoch, catGen)
 }
 
-// loadAndCache runs the loader under the (catalog, indicator, version)
-// SingleFlight, stamps [score, updatedAt, data], and writes it back
-// best-effort — and conditionally: the write lands only if the memo epoch
-// still matches what the caller observed before the loader ran, so an
-// invalidation cannot be undone by an in-flight compute (the value is still
-// returned to this caller; it just isn't cached). A loader error is wrapped
-// (loaderError) so finalize can distinguish it from an internal encode
-// error; a cache-WRITE failure is swallowed — the computed value is already
-// correct and is returned anyway.
-func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResult, hashKey string, lastUpdated float64, now int64, epoch string) (T, error) {
+// loadAndCache runs the loader under the (catalog, indicator, version,
+// barriers) SingleFlight, stamps [score, updatedAt, data], and writes it
+// back best-effort — and conditionally: the write lands only if both
+// barriers (indicator epoch, catalog removal generation) still match what
+// the caller observed before the loader ran, so an invalidation or removal
+// cannot be undone by an in-flight compute (the value is still returned to
+// this caller; it just isn't cached).
+//
+// The barriers are part of the flight key on purpose: a removal can leave
+// LastUpdated() unchanged (dropping a non-latest delta), so a caller that
+// probed AFTER the invalidation must not join a flight computed from the
+// pre-removal list and share its stale result — the barrier values differ,
+// so it starts its own flight.
+//
+// A loader error is wrapped (loaderError) so finalize can distinguish it
+// from an internal encode error; a cache-WRITE failure is swallowed — the
+// computed value is already correct and is returned anyway.
+func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResult, hashKey string, lastUpdated float64, now int64, epoch, catGen string) (T, error) {
 	var zero T
-	flightKey := fmt.Sprintf("%s:%s:%.6f", list.catalog, s.indicator, lastUpdated)
+	flightKey := fmt.Sprintf("%s:%s:%.6f:%s:%s", list.catalog, s.indicator, lastUpdated, epoch, catGen)
 	raw, err := c.sampleFlight.Do(flightKey, func() (string, error) {
 		result, lerr := s.loader(list)
 		if lerr != nil {
@@ -412,7 +457,9 @@ func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResu
 		if merr != nil {
 			return "", fmt.Errorf("marshal sample: %w", merr)
 		}
-		if werr := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey}, epoch, list.catalog, data).Err(); werr != nil {
+		if werr := c.sampleRdb.Eval(ctx, sampleWriteScript,
+			[]string{hashKey, c.reader.MakeSampleRemoveGenKey()},
+			epoch, catGen, list.catalog, data).Err(); werr != nil {
 			c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hset", "err": werr.Error()})
 		}
 		return string(data), nil

--- a/sample.go
+++ b/sample.go
@@ -54,6 +54,12 @@ type SampleMeta struct {
 	// UpdatedAt is the Redis-server wall clock (unix seconds) when the
 	// sample was computed; the basis for WithMaxAge.
 	UpdatedAt int64
+	// RemoveGen is the catalog's removal generation the sample was computed
+	// under ("0" until the first RemoveDelta). A cached entry is served only
+	// to a ListResult of the SAME generation: a removal can lower — or leave
+	// unchanged — the data version, so Score alone cannot tell that a value
+	// still reflects a removed write.
+	RemoveGen string
 }
 
 // SampleResult is one entry of Batch's output: a value, or an error
@@ -325,11 +331,17 @@ return 0
 `
 
 // sampleInvalidateScript bumps the epoch and deletes the catalogs' fields in
-// one atomic step. KEYS[1] = memo hash; ARGV = catalogs. Returns the number
-// of fields deleted.
+// one atomic step. The HDELs iterate rather than unpack(ARGV): unpack is
+// bounded by Lua's stack (~8k), and a large ops sweep must not die after the
+// epoch bump with the fields still in place. KEYS[1] = memo hash;
+// ARGV = catalogs. Returns the number of fields deleted.
 const sampleInvalidateScript = `
 redis.call("HINCRBY", KEYS[1], ":", 1)
-return redis.call("HDEL", KEYS[1], unpack(ARGV))
+local n = 0
+for i = 1, #ARGV do
+  n = n + redis.call("HDEL", KEYS[1], ARGV[i])
+end
+return n
 `
 
 // InvalidateSamples deletes the cached samples of one indicator for the given
@@ -374,12 +386,20 @@ func (c *Client) InvalidateSamples(ctx context.Context, indicator string, catalo
 }
 
 // isStale decides whether a cached entry must be recomputed. The data-
-// version floor is mandatory; maxAge and shouldRefresh only ADD triggers
-// (they can force a refresh, never suppress one the data version requires).
+// version floor and the removal-generation match are mandatory; maxAge and
+// shouldRefresh only ADD triggers (they can force a refresh, never suppress
+// one the mandatory checks require).
 func (s *Sampler[T]) isStale(meta SampleMeta, list *ListResult, peers map[string]*ListResult, now int64) bool {
 	lastUpdated := list.LastUpdated()
 	if !(meta.Score >= lastUpdated && meta.Score > 0) {
 		return true // data advanced past the cached version (or none) → refresh
+	}
+	// A removal can lower or preserve LastUpdated, so the floor above cannot
+	// see it: an entry computed under a different removal generation than
+	// the caller's ListResult must not be served (e.g. the post-removal
+	// sweep has not reached — or failed to reach — this memo hash yet).
+	if normalizeGen(meta.RemoveGen) != normalizeGen(list.removeGen) {
+		return true
 	}
 	// Compare in time.Duration so a sub-second maxAge keeps its value instead
 	// of truncating to 0 (which would mark every hit stale). The clock itself
@@ -466,7 +486,7 @@ func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResu
 		if lerr != nil {
 			return "", &loaderError{err: lerr}
 		}
-		data, merr := marshalSampleCache(SampleMeta{Score: lastUpdated, UpdatedAt: now}, result)
+		data, merr := marshalSampleCache(SampleMeta{Score: lastUpdated, UpdatedAt: now, RemoveGen: listGen}, result)
 		if merr != nil {
 			return "", fmt.Errorf("marshal sample: %w", merr)
 		}
@@ -517,15 +537,26 @@ type loaderError struct{ err error }
 func (e *loaderError) Error() string { return e.err.Error() }
 func (e *loaderError) Unwrap() error { return e.err }
 
-// Cache value format: a JSON array "[score, updatedAt, data]". score is the
-// data version and updatedAt the compute wall-clock; data is the sample.
+// normalizeGen maps the two spellings of "no removal ever" — a missing/empty
+// generation and the literal "0" — onto one value for comparison.
+func normalizeGen(g string) string {
+	if g == "" {
+		return "0"
+	}
+	return g
+}
+
+// Cache value format: a JSON array "[score, updatedAt, removeGen, data]".
+// score is the data version, updatedAt the compute wall-clock, removeGen the
+// catalog's removal generation at compute time; data is the sample. Older
+// 2/3-element formats fail to decode and read as a miss (recompute).
 func marshalSampleCache[T any](meta SampleMeta, data T) ([]byte, error) {
-	return json.Marshal([3]any{meta.Score, meta.UpdatedAt, data})
+	return json.Marshal([4]any{meta.Score, meta.UpdatedAt, normalizeGen(meta.RemoveGen), data})
 }
 
 func unmarshalSampleCache[T any](raw []byte) (SampleMeta, T, error) {
 	var (
-		arr  [3]json.RawMessage
+		arr  [4]json.RawMessage
 		meta SampleMeta
 		zero T
 	)
@@ -538,8 +569,11 @@ func unmarshalSampleCache[T any](raw []byte) (SampleMeta, T, error) {
 	if err := json.Unmarshal(arr[1], &meta.UpdatedAt); err != nil {
 		return meta, zero, err
 	}
+	if err := json.Unmarshal(arr[2], &meta.RemoveGen); err != nil {
+		return meta, zero, err
+	}
 	var data T
-	if err := json.Unmarshal(arr[2], &data); err != nil {
+	if err := json.Unmarshal(arr[3], &data); err != nil {
 		return meta, zero, err
 	}
 	return meta, data, nil

--- a/sample.go
+++ b/sample.go
@@ -430,24 +430,37 @@ func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult
 
 // loadAndCache runs the loader under the (catalog, indicator, version,
 // barriers) SingleFlight, stamps [score, updatedAt, data], and writes it
-// back best-effort — and conditionally: the write lands only if both
-// barriers (indicator epoch, catalog removal generation) still match what
-// the caller observed before the loader ran, so an invalidation or removal
-// cannot be undone by an in-flight compute (the value is still returned to
-// this caller; it just isn't cached).
+// back best-effort — and conditionally, behind three checks that together
+// guarantee a value computed from a pre-removal ListResult can never stick:
 //
-// The barriers are part of the flight key on purpose: a removal can leave
-// LastUpdated() unchanged (dropping a non-latest delta), so a caller that
-// probed AFTER the invalidation must not join a flight computed from the
-// pre-removal list and share its stale result — the barrier values differ,
-// so it starts its own flight.
+//  1. list-time recheck: the loader computed from list's ENTRIES, so the
+//     authoritative removal generation must still equal list.removeGen
+//     (captured atomically with those entries). This catches a removal that
+//     happened between the List and this call — probing the current value
+//     instead would happily bless a stale computation.
+//  2. probe-time catalog generation ("<prefix>:mrg", checked atomically in
+//     the write script): closes the window between the recheck and the
+//     write itself, and exists even for an indicator that has never cached
+//     anything.
+//  3. probe-time indicator epoch (also in the script): the
+//     InvalidateSamples barrier.
+//
+// The value is still returned to the caller in all cases; it just isn't
+// cached. The barriers are part of the flight key so callers holding
+// different generations never share a result — a removal can leave
+// LastUpdated() unchanged (dropping a non-latest delta), so the version
+// alone cannot separate them.
 //
 // A loader error is wrapped (loaderError) so finalize can distinguish it
 // from an internal encode error; a cache-WRITE failure is swallowed — the
 // computed value is already correct and is returned anyway.
 func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResult, hashKey string, lastUpdated float64, now int64, epoch, catGen string) (T, error) {
 	var zero T
-	flightKey := fmt.Sprintf("%s:%s:%.6f:%s:%s", list.catalog, s.indicator, lastUpdated, epoch, catGen)
+	listGen := list.removeGen
+	if listGen == "" {
+		listGen = "0"
+	}
+	flightKey := fmt.Sprintf("%s:%s:%.6f:%s:%s:%s", list.catalog, s.indicator, lastUpdated, epoch, catGen, listGen)
 	raw, err := c.sampleFlight.Do(flightKey, func() (string, error) {
 		result, lerr := s.loader(list)
 		if lerr != nil {
@@ -456,6 +469,11 @@ func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResu
 		data, merr := marshalSampleCache(SampleMeta{Score: lastUpdated, UpdatedAt: now}, result)
 		if merr != nil {
 			return "", fmt.Errorf("marshal sample: %w", merr)
+		}
+		if curGen, gerr := c.reader.RemoveGen(ctx, list.catalog); gerr != nil || curGen != listGen {
+			// Unreadable or moved generation: skip the write (never cache a
+			// value the current log may no longer support), keep the result.
+			return string(data), nil
 		}
 		if werr := c.sampleRdb.Eval(ctx, sampleWriteScript,
 			[]string{hashKey, c.reader.MakeSampleRemoveGenKey()},

--- a/sample_invalidate_test.go
+++ b/sample_invalidate_test.go
@@ -1,0 +1,63 @@
+package lake
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hkloudou/lake/v3/internal/index"
+)
+
+func TestInvalidateSamples_ValidatesBeforeRedis(t *testing.T) {
+	c := newDeadClient(t)
+	if _, err := c.InvalidateSamples(context.Background(), "bad|indicator", "users"); err == nil || !strings.Contains(err.Error(), "invalid indicator") {
+		t.Fatalf("expected invalid indicator error, got %v", err)
+	}
+	if _, err := c.InvalidateSamples(context.Background(), "views", "bad|name"); err == nil {
+		t.Fatal("expected invalid catalog error, got nil")
+	}
+	// No catalogs → trivially nothing to do, no Redis call.
+	if n, err := c.InvalidateSamples(context.Background(), "views"); err != nil || n != 0 {
+		t.Fatalf("empty catalogs: n=%d err=%v, want 0/nil", n, err)
+	}
+}
+
+// TestInvalidateSamples_ForcesRecompute_Redis pins the full memo lifecycle:
+// compute → cached (loader not re-run) → InvalidateSamples → recomputed.
+// This is the escape hatch for the two cases staleness policies cannot see —
+// a deleted catalog's lingering memo field, and a loader whose code changed
+// under an unchanged data version.
+func TestInvalidateSamples_ForcesRecompute_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+	c := New(prefix, rdb, memResolver())
+
+	ctx := context.Background()
+	list := &ListResult{client: c, catalog: "users", Entries: []index.DeltaInfo{{Score: 42}}}
+
+	var runs atomic.Int64
+	sampler := NewSampler[int]("views", func(*ListResult) (int, error) {
+		return int(runs.Add(1)), nil
+	})
+
+	if v, err := sampler.Sample(ctx, list); err != nil || v != 1 {
+		t.Fatalf("first Sample: v=%d err=%v, want 1/nil", v, err)
+	}
+	if v, err := sampler.Sample(ctx, list); err != nil || v != 1 {
+		t.Fatalf("cached Sample: v=%d err=%v, want 1/nil (loader must not re-run)", v, err)
+	}
+
+	n, err := c.InvalidateSamples(ctx, "views", "users")
+	if err != nil {
+		t.Fatalf("InvalidateSamples: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("InvalidateSamples removed %d entries, want 1", n)
+	}
+
+	if v, err := sampler.Sample(ctx, list); err != nil || v != 2 {
+		t.Fatalf("Sample after invalidate: v=%d err=%v, want 2/nil (recompute)", v, err)
+	}
+}

--- a/sample_invalidate_test.go
+++ b/sample_invalidate_test.go
@@ -378,6 +378,66 @@ func TestRemoveDeltaSweepsGlobPrefix_Redis(t *testing.T) {
 	}
 }
 
+// TestSampleUnsweptStaleEntryRejected_Redis pins the read-time generation
+// check: an entry the post-removal sweep failed to delete (simulated by
+// re-planting it) must NOT be served to a post-removal ListResult, even
+// though its Score satisfies the version floor.
+func TestSampleUnsweptStaleEntryRejected_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve)
+
+	ctx := context.Background()
+	h, err := c.WriteBegin(ctx, WriteBeginRequest{
+		Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+	})
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+	if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(`{"n":1}`)); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := c.WriteNotify(ctx, h); err != nil {
+		t.Fatalf("WriteNotify: %v", err)
+	}
+	pre := c.List(ctx, "users")
+	if pre.Err != nil || len(pre.Entries) != 1 {
+		t.Fatalf("List: err=%v entries=%d", pre.Err, len(pre.Entries))
+	}
+
+	// A pre-removal cached entry, planted as if the sweep had missed it:
+	// generation "0", score high enough to satisfy the version floor.
+	stale, _ := marshalSampleCache(SampleMeta{Score: pre.LastUpdated() + 100, UpdatedAt: 1, RemoveGen: "0"}, 111)
+	memoKey := c.reader.MakeSampleIndicatorKey("views")
+
+	if removed, err := c.RemoveDelta(ctx, "users", pre.Entries[0].TsSeq.String()); err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v", removed, err)
+	}
+	if err := c.sampleRdb.HSet(ctx, memoKey, "users", stale).Err(); err != nil {
+		t.Fatalf("plant stale entry: %v", err)
+	}
+
+	var runs atomic.Int64
+	sampler := NewSampler[int]("views", func(*ListResult) (int, error) {
+		runs.Add(1)
+		return 222, nil
+	})
+	// Post-removal list (generation "1") must reject the generation-"0" hit
+	// and recompute, despite the planted score beating the version floor.
+	if v, err := sampler.Sample(ctx, c.List(ctx, "users")); err != nil || v != 222 {
+		t.Fatalf("Sample: v=%d err=%v, want recomputed 222/nil", v, err)
+	}
+	if runs.Load() != 1 {
+		t.Fatalf("loader ran %d times, want 1 (stale hit must be rejected)", runs.Load())
+	}
+}
+
 // TestInvalidateSamples_NewFlightAfterInvalidation: a Sample that probes
 // AFTER an invalidation must not join a still-running pre-invalidation
 // loader (same catalog, indicator, and data version) and share its stale

--- a/sample_invalidate_test.go
+++ b/sample_invalidate_test.go
@@ -225,6 +225,15 @@ func TestSampleStaleListNotCached_Redis(t *testing.T) {
 		return int(runs.Add(1)), nil
 	})
 
+	// The exported generation accessor tracks the removal (predicates use it
+	// for peer-dependency baselines).
+	if g := staleList.RemoveGen(); g != "0" {
+		t.Fatalf("pre-removal RemoveGen() = %q, want \"0\"", g)
+	}
+	if g := c.List(ctx, "users").RemoveGen(); g != "1" {
+		t.Fatalf("post-removal RemoveGen() = %q, want \"1\"", g)
+	}
+
 	// Sampling the PRE-removal list: value returned, write-back dropped.
 	if v, err := sampler.Sample(ctx, staleList); err != nil || v != 1 {
 		t.Fatalf("stale-list Sample: v=%d err=%v, want 1/nil", v, err)

--- a/sample_invalidate_test.go
+++ b/sample_invalidate_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/hkloudou/lake/v3/internal/index"
+	"github.com/hkloudou/lake/v3/storage"
+	"github.com/hkloudou/lake/v3/storage/mem"
 )
 
 func TestInvalidateSamples_ValidatesBeforeRedis(t *testing.T) {
@@ -59,5 +61,170 @@ func TestInvalidateSamples_ForcesRecompute_Redis(t *testing.T) {
 
 	if v, err := sampler.Sample(ctx, list); err != nil || v != 2 {
 		t.Fatalf("Sample after invalidate: v=%d err=%v, want 2/nil (recompute)", v, err)
+	}
+}
+
+// TestInvalidateSamples_BarriersInFlightWrite_Redis pins the epoch barrier:
+// a compute that captured its epoch BEFORE an invalidation must not be able
+// to write its (now stale) value back afterwards — otherwise the write would
+// reinstate exactly what was just invalidated, and with the data version
+// unchanged nothing would ever evict it again.
+func TestInvalidateSamples_BarriersInFlightWrite_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+	c := New(prefix, rdb, memResolver())
+
+	ctx := context.Background()
+	hashKey := c.reader.MakeSampleIndicatorKey("views")
+	staleValue, _ := marshalSampleCache(SampleMeta{Score: 42, UpdatedAt: 1}, 1)
+
+	// An in-flight compute captured epoch "0" (no invalidation yet)…
+	inFlightEpoch := "0"
+	// …then the invalidation lands…
+	if _, err := c.InvalidateSamples(ctx, "views", "users"); err != nil {
+		t.Fatalf("InvalidateSamples: %v", err)
+	}
+	// …and the in-flight write-back must be discarded.
+	if err := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey}, inFlightEpoch, "users", staleValue).Err(); err != nil {
+		t.Fatalf("stale write eval: %v", err)
+	}
+	if n, err := c.sampleRdb.HExists(ctx, hashKey, "users").Result(); err != nil || n {
+		t.Fatalf("stale in-flight write survived the epoch barrier (exists=%v err=%v)", n, err)
+	}
+
+	// A write that observed the post-invalidation epoch lands normally.
+	epoch, err := c.sampleRdb.HGet(ctx, hashKey, sampleEpochField).Result()
+	if err != nil {
+		t.Fatalf("read epoch: %v", err)
+	}
+	if err := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey}, epoch, "users", staleValue).Err(); err != nil {
+		t.Fatalf("fresh write eval: %v", err)
+	}
+	if n, err := c.sampleRdb.HExists(ctx, hashKey, "users").Result(); err != nil || !n {
+		t.Fatalf("current-epoch write was wrongly discarded (exists=%v err=%v)", n, err)
+	}
+}
+
+// TestRemoveDeltaInvalidatesSamples_Redis: removing a delta lowers the
+// catalog's data version, so the version floor alone would keep serving a
+// sample computed WITH the removed write forever. RemoveDelta therefore
+// sweeps every indicator's memo entry for the catalog.
+func TestRemoveDeltaInvalidatesSamples_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve)
+
+	ctx := context.Background()
+	h, err := c.WriteBegin(ctx, WriteBeginRequest{
+		Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+	})
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+	if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(`{"n":1}`)); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := c.WriteNotify(ctx, h); err != nil {
+		t.Fatalf("WriteNotify: %v", err)
+	}
+
+	var runs atomic.Int64
+	sampler := NewSampler[int]("views", func(*ListResult) (int, error) {
+		return int(runs.Add(1)), nil
+	})
+	list := c.List(ctx, "users")
+	if list.Err != nil || len(list.Entries) != 1 {
+		t.Fatalf("List: err=%v entries=%d", list.Err, len(list.Entries))
+	}
+	if v, err := sampler.Sample(ctx, list); err != nil || v != 1 {
+		t.Fatalf("prime Sample: v=%d err=%v, want 1/nil", v, err)
+	}
+	if v, err := sampler.Sample(ctx, list); err != nil || v != 1 {
+		t.Fatalf("cached Sample: v=%d err=%v, want 1/nil", v, err)
+	}
+
+	removed, err := c.RemoveDelta(ctx, "users", list.Entries[0].TsSeq.String())
+	if err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v", removed, err)
+	}
+
+	// The memo entry is gone; the next sample recomputes from the
+	// post-removal state instead of serving the removed write's value.
+	if v, err := sampler.Sample(ctx, c.List(ctx, "users")); err != nil || v != 2 {
+		t.Fatalf("Sample after RemoveDelta: v=%d err=%v, want 2/nil (recompute)", v, err)
+	}
+}
+
+// TestRemoveDeltaBlocksStaleSnapshot_Redis pins the client-level barrier: a
+// snapshot save whose data came from a read that listed the (since-removed)
+// delta must not land; a save from a post-removal read lands normally.
+func TestRemoveDeltaBlocksStaleSnapshot_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve, WithSnapTarget("mem", "snaps"))
+
+	ctx := context.Background()
+	write := func(body string) {
+		t.Helper()
+		h, err := c.WriteBegin(ctx, WriteBeginRequest{
+			Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+		})
+		if err != nil {
+			t.Fatalf("WriteBegin: %v", err)
+		}
+		if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(body)); err != nil {
+			t.Fatalf("upload: %v", err)
+		}
+		if err := c.WriteNotify(ctx, h); err != nil {
+			t.Fatalf("WriteNotify: %v", err)
+		}
+	}
+	write(`{"secret":true}`)
+
+	// A reader listed the delta (no Read → no auto-snapshot), then the delta
+	// is removed. The reader's snapshot publication must be dropped.
+	list := c.List(ctx, "users")
+	if list.Err != nil || len(list.Entries) != 1 {
+		t.Fatalf("List: err=%v entries=%d", list.Err, len(list.Entries))
+	}
+	stale := list.NextSnap()
+	if removed, err := c.RemoveDelta(ctx, "users", list.Entries[0].TsSeq.String()); err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v", removed, err)
+	}
+	if _, err := c.saveSnapshot(ctx, "users", stale.StopTsSeq, list.removeGen, []byte(`{"secret":true}`)); err != nil {
+		t.Fatalf("stale saveSnapshot: %v", err)
+	}
+	if snap, _ := c.reader.GetLatestSnap(ctx, "users"); snap != nil {
+		t.Fatalf("stale snapshot resurrected the removed delta: %+v", snap)
+	}
+
+	// A post-removal read snapshots normally (new write, current generation).
+	write(`{"clean":true}`)
+	list = c.List(ctx, "users")
+	if list.Err != nil || len(list.Entries) != 1 {
+		t.Fatalf("List after rewrite: err=%v entries=%d", list.Err, len(list.Entries))
+	}
+	if _, err := c.saveSnapshot(ctx, "users", list.NextSnap().StopTsSeq, list.removeGen, []byte(`{"clean":true}`)); err != nil {
+		t.Fatalf("fresh saveSnapshot: %v", err)
+	}
+	snap, err := c.reader.GetLatestSnap(ctx, "users")
+	if err != nil || snap == nil {
+		t.Fatalf("fresh snapshot missing: snap=%+v err=%v", snap, err)
+	}
+	if snap.StopTsSeq != list.Entries[0].TsSeq {
+		t.Fatalf("fresh snapshot at wrong stop: %v, want %v", snap.StopTsSeq, list.Entries[0].TsSeq)
 	}
 }

--- a/sample_invalidate_test.go
+++ b/sample_invalidate_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/hkloudou/lake/v3/internal/index"
 	"github.com/hkloudou/lake/v3/storage"
@@ -77,6 +78,7 @@ func TestInvalidateSamples_BarriersInFlightWrite_Redis(t *testing.T) {
 
 	ctx := context.Background()
 	hashKey := c.reader.MakeSampleIndicatorKey("views")
+	genKey := c.reader.MakeSampleRemoveGenKey()
 	staleValue, _ := marshalSampleCache(SampleMeta{Score: 42, UpdatedAt: 1}, 1)
 
 	// An in-flight compute captured epoch "0" (no invalidation yet)…
@@ -86,7 +88,7 @@ func TestInvalidateSamples_BarriersInFlightWrite_Redis(t *testing.T) {
 		t.Fatalf("InvalidateSamples: %v", err)
 	}
 	// …and the in-flight write-back must be discarded.
-	if err := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey}, inFlightEpoch, "users", staleValue).Err(); err != nil {
+	if err := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey, genKey}, inFlightEpoch, "0", "users", staleValue).Err(); err != nil {
 		t.Fatalf("stale write eval: %v", err)
 	}
 	if n, err := c.sampleRdb.HExists(ctx, hashKey, "users").Result(); err != nil || n {
@@ -98,11 +100,146 @@ func TestInvalidateSamples_BarriersInFlightWrite_Redis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read epoch: %v", err)
 	}
-	if err := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey}, epoch, "users", staleValue).Err(); err != nil {
+	if err := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey, genKey}, epoch, "0", "users", staleValue).Err(); err != nil {
 		t.Fatalf("fresh write eval: %v", err)
 	}
 	if n, err := c.sampleRdb.HExists(ctx, hashKey, "users").Result(); err != nil || !n {
 		t.Fatalf("current-epoch write was wrongly discarded (exists=%v err=%v)", n, err)
+	}
+}
+
+// TestRemoveDeltaBlocksUnseenIndicatorWrite_Redis pins the catalog-level
+// barrier for an indicator that has NEVER cached anything: its memo hash
+// does not exist, so no key sweep can reach it — but a first-ever compute
+// that read the pre-removal list must still not land its value after the
+// removal. The "<prefix>:mrg" generation exists independently of memo
+// hashes and blocks exactly that write.
+func TestRemoveDeltaBlocksUnseenIndicatorWrite_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve)
+
+	ctx := context.Background()
+	h, err := c.WriteBegin(ctx, WriteBeginRequest{
+		Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+	})
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+	if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(`{"n":1}`)); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := c.WriteNotify(ctx, h); err != nil {
+		t.Fatalf("WriteNotify: %v", err)
+	}
+	list := c.List(ctx, "users")
+	if list.Err != nil || len(list.Entries) != 1 {
+		t.Fatalf("List: err=%v entries=%d", list.Err, len(list.Entries))
+	}
+
+	// A first-ever compute for indicator "fresh" captured its barriers
+	// before the removal: memo hash absent → epoch "0", gen "0".
+	hashKey := c.reader.MakeSampleIndicatorKey("fresh")
+	genKey := c.reader.MakeSampleRemoveGenKey()
+	staleValue, _ := marshalSampleCache(SampleMeta{Score: list.LastUpdated(), UpdatedAt: 1}, 1)
+
+	if removed, err := c.RemoveDelta(ctx, "users", list.Entries[0].TsSeq.String()); err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v", removed, err)
+	}
+
+	// The pre-removal compute's write-back must be discarded even though its
+	// memo hash never existed for the sweep to find.
+	if err := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey, genKey}, "0", "0", "users", staleValue).Err(); err != nil {
+		t.Fatalf("stale write eval: %v", err)
+	}
+	if n, err := c.sampleRdb.HExists(ctx, hashKey, "users").Result(); err != nil || n {
+		t.Fatalf("pre-removal write for an unseen indicator landed (exists=%v err=%v)", n, err)
+	}
+
+	// A compute that observed the post-removal generation caches normally.
+	gen, err := c.sampleRdb.HGet(ctx, genKey, "users").Result()
+	if err != nil || gen != "1" {
+		t.Fatalf("removal gen = %q err=%v, want \"1\"", gen, err)
+	}
+	if err := c.sampleRdb.Eval(ctx, sampleWriteScript, []string{hashKey, genKey}, "0", gen, "users", staleValue).Err(); err != nil {
+		t.Fatalf("fresh write eval: %v", err)
+	}
+	if n, err := c.sampleRdb.HExists(ctx, hashKey, "users").Result(); err != nil || !n {
+		t.Fatalf("current-generation write was wrongly discarded (exists=%v err=%v)", n, err)
+	}
+}
+
+// TestInvalidateSamples_NewFlightAfterInvalidation: a Sample that probes
+// AFTER an invalidation must not join a still-running pre-invalidation
+// loader (same catalog, indicator, and data version) and share its stale
+// result — the barrier values are part of the flight key, so it computes
+// its own.
+func TestInvalidateSamples_NewFlightAfterInvalidation(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+	c := New(prefix, rdb, memResolver())
+
+	ctx := context.Background()
+	list := &ListResult{client: c, catalog: "users", Entries: []index.DeltaInfo{{Score: 42}}}
+
+	gate := make(chan struct{})
+	var runs atomic.Int64
+	sampler := NewSampler[int]("views", func(*ListResult) (int, error) {
+		n := int(runs.Add(1))
+		if n == 1 {
+			<-gate // first (pre-invalidation) loader hangs mid-compute
+		}
+		return n, nil
+	})
+
+	first := make(chan int, 1)
+	go func() {
+		v, _ := sampler.Sample(ctx, list)
+		first <- v
+	}()
+	if !waitFor(func() bool { return runs.Load() == 1 }) {
+		t.Fatal("first loader did not start")
+	}
+
+	if _, err := c.InvalidateSamples(ctx, "views", "users"); err != nil {
+		t.Fatalf("InvalidateSamples: %v", err)
+	}
+
+	// Post-invalidation call: must run its own loader (value 2), not join
+	// the hung pre-invalidation flight and inherit its value 1.
+	done := make(chan struct{})
+	var v2 int
+	var err2 error
+	go func() {
+		v2, err2 = sampler.Sample(ctx, list)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-invalidation Sample joined the hung pre-invalidation flight")
+	}
+	if err2 != nil || v2 != 2 {
+		t.Fatalf("post-invalidation Sample: v=%d err=%v, want 2/nil", v2, err2)
+	}
+
+	close(gate)
+	if v1 := <-first; v1 != 1 {
+		t.Fatalf("pre-invalidation Sample: v=%d, want 1", v1)
+	}
+	// And its stale write-back must not have landed.
+	if raw, err := c.sampleRdb.HGet(ctx, c.reader.MakeSampleIndicatorKey("views"), "users").Bytes(); err == nil {
+		_, cachedVal, derr := unmarshalSampleCache[int](raw)
+		if derr == nil && cachedVal == 1 {
+			t.Fatal("stale pre-invalidation value was cached")
+		}
 	}
 }
 

--- a/sample_invalidate_test.go
+++ b/sample_invalidate_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hkloudou/lake/v3/internal/index"
+	"github.com/hkloudou/lake/v3/internal/objkey"
 	"github.com/hkloudou/lake/v3/storage"
 	"github.com/hkloudou/lake/v3/storage/mem"
 )
@@ -172,6 +173,208 @@ func TestRemoveDeltaBlocksUnseenIndicatorWrite_Redis(t *testing.T) {
 	}
 	if n, err := c.sampleRdb.HExists(ctx, hashKey, "users").Result(); err != nil || !n {
 		t.Fatalf("current-generation write was wrongly discarded (exists=%v err=%v)", n, err)
+	}
+}
+
+// TestSampleStaleListNotCached_Redis pins the list-time generation recheck:
+// a loader that computed from a ListResult taken BEFORE a RemoveDelta must
+// not cache its result AFTER the removal — the probe-time barriers look
+// current, but the entries the value was derived from are not. The caller
+// still gets the value; only the write-back is dropped.
+func TestSampleStaleListNotCached_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve)
+
+	ctx := context.Background()
+	write := func(body string) {
+		t.Helper()
+		h, err := c.WriteBegin(ctx, WriteBeginRequest{
+			Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+		})
+		if err != nil {
+			t.Fatalf("WriteBegin: %v", err)
+		}
+		if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(body)); err != nil {
+			t.Fatalf("upload: %v", err)
+		}
+		if err := c.WriteNotify(ctx, h); err != nil {
+			t.Fatalf("WriteNotify: %v", err)
+		}
+	}
+	write(`{"a":1}`)
+	write(`{"b":2}`)
+
+	staleList := c.List(ctx, "users")
+	if staleList.Err != nil || len(staleList.Entries) != 2 {
+		t.Fatalf("List: err=%v entries=%d", staleList.Err, len(staleList.Entries))
+	}
+
+	if removed, err := c.RemoveDelta(ctx, "users", staleList.Entries[0].TsSeq.String()); err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v", removed, err)
+	}
+
+	var runs atomic.Int64
+	sampler := NewSampler[int]("views", func(*ListResult) (int, error) {
+		return int(runs.Add(1)), nil
+	})
+
+	// Sampling the PRE-removal list: value returned, write-back dropped.
+	if v, err := sampler.Sample(ctx, staleList); err != nil || v != 1 {
+		t.Fatalf("stale-list Sample: v=%d err=%v, want 1/nil", v, err)
+	}
+	if n, err := c.sampleRdb.HExists(ctx, c.reader.MakeSampleIndicatorKey("views"), "users").Result(); err != nil || n {
+		t.Fatalf("stale-list result was cached (exists=%v err=%v)", n, err)
+	}
+
+	// A fresh list samples, recomputes, and caches normally.
+	if v, err := sampler.Sample(ctx, c.List(ctx, "users")); err != nil || v != 2 {
+		t.Fatalf("fresh-list Sample: v=%d err=%v, want 2/nil", v, err)
+	}
+	if n, err := c.sampleRdb.HExists(ctx, c.reader.MakeSampleIndicatorKey("views"), "users").Result(); err != nil || !n {
+		t.Fatalf("fresh-list result missing from cache (exists=%v err=%v)", n, err)
+	}
+}
+
+// TestRemoveDeltaSnapshotPathIsolation_Redis pins the per-generation object
+// path: removing a non-latest delta leaves the stop unchanged, so the stale
+// and fresh generations save snapshots FOR THE SAME STOP. The stale save's
+// Put must not be able to overwrite the object the published pointer
+// references — even when it finishes last.
+func TestRemoveDeltaSnapshotPathIsolation_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve, WithSnapTarget("mem", "snaps"))
+
+	ctx := context.Background()
+	write := func(body string) {
+		t.Helper()
+		h, err := c.WriteBegin(ctx, WriteBeginRequest{
+			Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+		})
+		if err != nil {
+			t.Fatalf("WriteBegin: %v", err)
+		}
+		if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(body)); err != nil {
+			t.Fatalf("upload: %v", err)
+		}
+		if err := c.WriteNotify(ctx, h); err != nil {
+			t.Fatalf("WriteNotify: %v", err)
+		}
+	}
+	write(`{"a":1}`)
+	write(`{"b":2}`)
+
+	preList := c.List(ctx, "users")
+	if preList.Err != nil || len(preList.Entries) != 2 {
+		t.Fatalf("pre List: err=%v entries=%d", preList.Err, len(preList.Entries))
+	}
+	if removed, err := c.RemoveDelta(ctx, "users", preList.Entries[0].TsSeq.String()); err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v", removed, err)
+	}
+	postList := c.List(ctx, "users")
+	if postList.Err != nil || len(postList.Entries) != 1 {
+		t.Fatalf("post List: err=%v entries=%d", postList.Err, len(postList.Entries))
+	}
+	if preList.NextSnap().StopTsSeq != postList.NextSnap().StopTsSeq {
+		t.Fatal("test setup: stops must be identical across the removal")
+	}
+
+	// The fresh generation publishes first…
+	freshURI, err := c.saveSnapshot(ctx, "users", postList.NextSnap().StopTsSeq, postList.removeGen, []byte(`{"fresh":true}`))
+	if err != nil {
+		t.Fatalf("fresh saveSnapshot: %v", err)
+	}
+	// …then the stale generation's save finishes LAST (the overwrite race).
+	staleURI, err := c.saveSnapshot(ctx, "users", preList.NextSnap().StopTsSeq, preList.removeGen, []byte(`{"stale":true}`))
+	if err != nil {
+		t.Fatalf("stale saveSnapshot: %v", err)
+	}
+	if staleURI == freshURI {
+		t.Fatalf("generations share an object path: %s", freshURI)
+	}
+
+	snap, err := c.reader.GetLatestSnap(ctx, "users")
+	if err != nil || snap == nil {
+		t.Fatalf("GetLatestSnap: snap=%+v err=%v", snap, err)
+	}
+	if snap.URI != freshURI {
+		t.Fatalf("pointer = %s, want the fresh generation's %s", snap.URI, freshURI)
+	}
+	_, _, path, err := objkey.ParseURI(snap.URI)
+	if err != nil {
+		t.Fatalf("parse pointer URI: %v", err)
+	}
+	data, err := store.Bucket("snaps").Get(ctx, "users", path)
+	if err != nil {
+		t.Fatalf("fetch pointer object: %v", err)
+	}
+	if string(data) != `{"fresh":true}` {
+		t.Fatalf("pointer object overwritten by the stale generation: %s", data)
+	}
+}
+
+// TestRemoveDeltaSweepsGlobPrefix_Redis: a deployment prefix may contain
+// Redis MATCH metacharacters; the memo sweep must still reach this
+// deployment's literal keys (unescaped, "p[g]…" would match "pg…" instead).
+func TestRemoveDeltaSweepsGlobPrefix_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t) + "[g]*?"
+	t.Cleanup(func() {
+		rdb.Del(context.Background(),
+			prefix+":d:users", prefix+":s", prefix+":m:views", prefix+":mrg")
+	})
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, provider, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve)
+
+	ctx := context.Background()
+	h, err := c.WriteBegin(ctx, WriteBeginRequest{
+		Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+	})
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+	if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(`{"n":1}`)); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := c.WriteNotify(ctx, h); err != nil {
+		t.Fatalf("WriteNotify: %v", err)
+	}
+	list := c.List(ctx, "users")
+	if list.Err != nil || len(list.Entries) != 1 {
+		t.Fatalf("List: err=%v entries=%d", list.Err, len(list.Entries))
+	}
+
+	sampler := NewSampler[int]("views", func(*ListResult) (int, error) { return 7, nil })
+	if _, err := sampler.Sample(ctx, list); err != nil {
+		t.Fatalf("prime Sample: %v", err)
+	}
+	memoKey := c.reader.MakeSampleIndicatorKey("views")
+	if n, err := c.sampleRdb.HExists(ctx, memoKey, "users").Result(); err != nil || !n {
+		t.Fatalf("prime not cached (exists=%v err=%v)", n, err)
+	}
+
+	if removed, err := c.RemoveDelta(ctx, "users", list.Entries[0].TsSeq.String()); err != nil || !removed {
+		t.Fatalf("RemoveDelta: removed=%v err=%v", removed, err)
+	}
+	if n, err := c.sampleRdb.HExists(ctx, memoKey, "users").Result(); err != nil || n {
+		t.Fatalf("glob-prefix memo hash escaped the sweep (exists=%v err=%v)", n, err)
 	}
 }
 

--- a/sample_test.go
+++ b/sample_test.go
@@ -13,11 +13,11 @@ func listAt(score float64) *ListResult {
 	return &ListResult{Entries: []index.DeltaInfo{{Score: score}}}
 }
 
-// TestSampleCacheCodec round-trips the [score, updatedAt, data] format and
-// confirms the legacy 2-element [score, data] format fails to decode (so a
-// reader treats it as a miss and recomputes).
+// TestSampleCacheCodec round-trips the [score, updatedAt, removeGen, data]
+// format and confirms the legacy shorter formats fail to decode (so a
+// reader treats them as a miss and recomputes).
 func TestSampleCacheCodec(t *testing.T) {
-	raw, err := marshalSampleCache(SampleMeta{Score: 12.5, UpdatedAt: 1700}, map[string]int{"a": 1})
+	raw, err := marshalSampleCache(SampleMeta{Score: 12.5, UpdatedAt: 1700, RemoveGen: "3"}, map[string]int{"a": 1})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -25,16 +25,25 @@ func TestSampleCacheCodec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if meta.Score != 12.5 || meta.UpdatedAt != 1700 {
+	if meta.Score != 12.5 || meta.UpdatedAt != 1700 || meta.RemoveGen != "3" {
 		t.Fatalf("meta round-trip: got %+v", meta)
 	}
 	if data["a"] != 1 {
 		t.Fatalf("data round-trip: got %+v", data)
 	}
 
-	// Legacy 2-element format must NOT decode as a valid 3-element entry.
-	if _, _, err := unmarshalSampleCache[map[string]int]([]byte(`[12.5,{"a":1}]`)); err == nil {
-		t.Fatal("legacy 2-element cache value must fail to decode (forces recompute)")
+	// An empty generation is stored normalized, so a decoded entry always
+	// compares equal against a no-removals ListResult.
+	raw, _ = marshalSampleCache(SampleMeta{Score: 1, UpdatedAt: 1}, 0)
+	if meta, _, err := unmarshalSampleCache[int](raw); err != nil || meta.RemoveGen != "0" {
+		t.Fatalf("normalized gen: meta=%+v err=%v, want RemoveGen \"0\"", meta, err)
+	}
+
+	// Legacy 2- and 3-element formats must NOT decode as valid entries.
+	for _, legacy := range []string{`[12.5,{"a":1}]`, `[12.5,1700,{"a":1}]`} {
+		if _, _, err := unmarshalSampleCache[map[string]int]([]byte(legacy)); err == nil {
+			t.Fatalf("legacy cache value %s must fail to decode (forces recompute)", legacy)
+		}
 	}
 }
 
@@ -77,6 +86,20 @@ func TestSamplerIsStale(t *testing.T) {
 	// Sentinel score 0 is never a valid hit (matches the score>0 rule).
 	if !base.isStale(SampleMeta{Score: 0}, listAt(0), noPeers, 0) {
 		t.Error("zero score must be stale")
+	}
+	// Removal-generation mismatch is mandatory staleness in BOTH directions:
+	// the entry was not computed from the caller's view of the log.
+	if !base.isStale(SampleMeta{Score: 100, RemoveGen: "1"}, listAt(100), noPeers, 0) {
+		t.Error("entry from an older list generation must be stale")
+	}
+	genList := listAt(100)
+	genList.removeGen = "2"
+	if !base.isStale(SampleMeta{Score: 100, RemoveGen: "1"}, genList, noPeers, 0) {
+		t.Error("generation mismatch must be stale")
+	}
+	genList.removeGen = "1"
+	if base.isStale(SampleMeta{Score: 100, RemoveGen: "1"}, genList, noPeers, 0) {
+		t.Error("matching generations must be fresh")
 	}
 
 	// maxAge: fresh within the window, stale past it.

--- a/snapshot.go
+++ b/snapshot.go
@@ -32,7 +32,20 @@ func (c *Client) saveSnapshot(ctx context.Context, catalog string, stop index.Ti
 		return "", nil
 	}
 	return c.snapFlight.Do(fmt.Sprintf("%s_%s_%s", catalog, stop, removeGen), func() (string, error) {
-		path := objkey.SnapPath(catalog, stop.String())
+		// The object path must be unique per (stop, removal generation), not
+		// just per stop: removing a non-latest delta leaves the stop
+		// unchanged, and if both generations shared one path, the stale
+		// generation's Put could finish LAST and overwrite the bytes the
+		// already-published pointer references — resurrecting the removed
+		// write behind AddSnap's back. Same stop + same generation implies
+		// identical content, so sharing within a generation stays benign.
+		// Readers fetch the URI recorded in the pointer verbatim, so the
+		// name shape is free to vary; gen 0 keeps the legacy name.
+		name := stop.String()
+		if removeGen != "" && removeGen != "0" {
+			name += "-g" + removeGen
+		}
+		path := objkey.SnapPath(catalog, name)
 		st, err := c.storageFor(storage.Snap, c.snapProvider, c.snapBucket)
 		if err != nil {
 			return "", fmt.Errorf("resolve snap target: %w", err)

--- a/snapshot.go
+++ b/snapshot.go
@@ -21,15 +21,17 @@ func (c *Client) IterateSnaps(ctx context.Context, fn func(catalog string, snap 
 }
 
 // saveSnapshot writes snap bytes to the configured snap target and upserts the
-// Redis hash entry (as [tsSeq, uri]) — monotonically: AddSnap drops the upsert
-// if a newer snap already landed, so racing saves can never regress the
-// pointer. No-op when no snap target is configured. SingleFlight on
-// (catalog, stop) dedupes concurrent saves within this process.
-func (c *Client) saveSnapshot(ctx context.Context, catalog string, stop index.TimeSeqID, data []byte) (string, error) {
+// Redis hash entry (as [tsSeq, uri]) — monotonically, and only if removeGen
+// still matches the catalog's removal generation: AddSnap drops the upsert if
+// a newer snap already landed OR a RemoveDelta interleaved since the read
+// that produced data (which would otherwise resurrect the removed write).
+// No-op when no snap target is configured. SingleFlight on (catalog, stop,
+// gen) dedupes concurrent saves within this process.
+func (c *Client) saveSnapshot(ctx context.Context, catalog string, stop index.TimeSeqID, removeGen string, data []byte) (string, error) {
 	if c.snapProvider == "" || c.snapBucket == "" {
 		return "", nil
 	}
-	return c.snapFlight.Do(fmt.Sprintf("%s_%s", catalog, stop), func() (string, error) {
+	return c.snapFlight.Do(fmt.Sprintf("%s_%s_%s", catalog, stop, removeGen), func() (string, error) {
 		path := objkey.SnapPath(catalog, stop.String())
 		st, err := c.storageFor(storage.Snap, c.snapProvider, c.snapBucket)
 		if err != nil {
@@ -39,7 +41,7 @@ func (c *Client) saveSnapshot(ctx context.Context, catalog string, stop index.Ti
 			return "", fmt.Errorf("save snapshot: %w", err)
 		}
 		uri := objkey.BuildURI(c.snapProvider, c.snapBucket, path)
-		if err := c.writer.AddSnap(ctx, catalog, stop, uri); err != nil {
+		if err := c.writer.AddSnap(ctx, catalog, stop, uri, removeGen); err != nil {
 			return "", fmt.Errorf("index snapshot: %w", err)
 		}
 		return uri, nil

--- a/write.go
+++ b/write.go
@@ -219,6 +219,13 @@ func (c *Client) WriteNotify(ctx context.Context, h *WriteHandle) error {
 		if !hmac.Equal([]byte(c.signHandle(h)), []byte(h.Signature)) {
 			return errors.New("invalid handle signature")
 		}
+		// The signature authenticates ExpiresAt, so enforce it too: a leaked
+		// signed handle must not be replayable indefinitely. (Without a
+		// secret the field is client-editable, so checking it there would
+		// only be theater.)
+		if now := time.Now().Unix(); now > h.ExpiresAt {
+			return fmt.Errorf("handle expired at %d (now %d)", h.ExpiresAt, now)
+		}
 	}
 	_, _, err = c.writer.Notify(ctx, h.Catalog, h.Path, h.MergeType, h.URI)
 	return err

--- a/write.go
+++ b/write.go
@@ -2,8 +2,11 @@ package lake
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -50,6 +53,10 @@ type WriteHandle struct {
 	UploadMethod  string            `json:"uploadMethod"`
 	UploadHeaders map[string]string `json:"uploadHeaders"`
 	ExpiresAt     int64             `json:"expiresAt"` // unix seconds
+	// Signature authenticates the handle's identity fields when the Client
+	// was built WithHandleSecret; empty otherwise. Clients must echo it back
+	// unchanged.
+	Signature string `json:"signature,omitempty"`
 }
 
 // WriteBeginOption tunes the presign call.
@@ -128,7 +135,7 @@ func (c *Client) WriteBegin(ctx context.Context, req WriteBeginRequest, opts ...
 	if err != nil {
 		return nil, fmt.Errorf("presign put: %w", err)
 	}
-	return &WriteHandle{
+	h := &WriteHandle{
 		Catalog:       req.Catalog,
 		Path:          req.Path,
 		MergeType:     req.MergeType,
@@ -141,7 +148,24 @@ func (c *Client) WriteBegin(ctx context.Context, req WriteBeginRequest, opts ...
 		UploadMethod:  upload.Method,
 		UploadHeaders: upload.Headers,
 		ExpiresAt:     time.Now().Add(o.ttl).Unix(),
-	}, nil
+	}
+	if len(c.handleSecret) > 0 {
+		h.Signature = c.signHandle(h)
+	}
+	return h, nil
+}
+
+// signHandle computes the HMAC-SHA256 over the handle's identity fields —
+// exactly the ones WriteNotify acts on plus ExpiresAt. The payload is a JSON
+// string array, so no field value can forge a boundary into a neighbour.
+func (c *Client) signHandle(h *WriteHandle) string {
+	payload, _ := json.Marshal([6]string{
+		h.Catalog, h.Path, strconv.Itoa(int(h.MergeType)),
+		h.UUID, h.URI, strconv.FormatInt(h.ExpiresAt, 10),
+	})
+	mac := hmac.New(sha256.New, c.handleSecret)
+	mac.Write(payload)
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 // WriteNotify finalises a write: allocates a tsSeq and atomically records the
@@ -152,6 +176,9 @@ func (c *Client) WriteBegin(ctx context.Context, req WriteBeginRequest, opts ...
 // the handle to its own catalog: the URI's object path must be exactly the
 // delta path WriteBegin derived for (Catalog, UUID). A tampered handle can
 // therefore never point a catalog's index at another catalog's objects.
+// With WithHandleSecret configured, Notify additionally requires a valid
+// HMAC signature over the identity fields, pinning Path / MergeType /
+// ExpiresAt to what WriteBegin issued.
 //
 // Notify is NOT idempotent — duplicate calls produce duplicate deltas (each
 // with its own tsSeq, all referencing the same URI). For Replace / RFC7396,
@@ -184,6 +211,14 @@ func (c *Client) WriteNotify(ctx context.Context, h *WriteHandle) error {
 	}
 	if want := objkey.DeltaPath(h.Catalog, h.UUID); path != want {
 		return fmt.Errorf("handle URI path %q does not match catalog/uuid (want %q)", path, want)
+	}
+	if len(c.handleSecret) > 0 {
+		if h.Signature == "" {
+			return errors.New("handle signature required")
+		}
+		if !hmac.Equal([]byte(c.signHandle(h)), []byte(h.Signature)) {
+			return errors.New("invalid handle signature")
+		}
 	}
 	_, _, err = c.writer.Notify(ctx, h.Catalog, h.Path, h.MergeType, h.URI)
 	return err

--- a/write_signature_test.go
+++ b/write_signature_test.go
@@ -1,0 +1,132 @@
+package lake
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hkloudou/lake/v3/internal/objkey"
+	"github.com/hkloudou/lake/v3/storage"
+	"github.com/hkloudou/lake/v3/storage/mem"
+	"github.com/redis/go-redis/v9"
+	"github.com/tidwall/gjson"
+)
+
+// newSignedDeadClient is a Client with handle signing on and an unreachable
+// index Redis — WriteBegin never touches Redis and signature rejection in
+// WriteNotify happens before the Redis call, so both are testable offline.
+func newSignedDeadClient(t *testing.T, secret string) *Client {
+	t.Helper()
+	store := mem.New()
+	resolve := func(_ storage.Kind, _, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	rdb := redis.NewClient(&redis.Options{Addr: unreachableRedis, DialTimeout: 200 * time.Millisecond})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return New("sigtest", rdb, resolve, WithHandleSecret([]byte(secret)))
+}
+
+func beginSigned(t *testing.T, c *Client) *WriteHandle {
+	t.Helper()
+	h, err := c.WriteBegin(context.Background(), WriteBeginRequest{
+		Catalog: "users", Path: "/profile", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+	})
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+	if h.Signature == "" {
+		t.Fatal("WithHandleSecret client must sign the handle")
+	}
+	return h
+}
+
+func TestHandleSignature_RejectsTampering(t *testing.T) {
+	c := newSignedDeadClient(t, "s3cret")
+	ctx := context.Background()
+
+	// Each mutation of a signed identity field must be rejected before Redis.
+	tampers := map[string]func(*WriteHandle){
+		"path":      func(h *WriteHandle) { h.Path = "/other" },
+		"mergeType": func(h *WriteHandle) { h.MergeType = MergeTypeRFC7396 },
+		"expiresAt": func(h *WriteHandle) { h.ExpiresAt += 3600 },
+		"signature": func(h *WriteHandle) { h.Signature = strings.Repeat("0", len(h.Signature)) },
+	}
+	for name, tamper := range tampers {
+		h := beginSigned(t, c)
+		tamper(h)
+		if err := c.WriteNotify(ctx, h); err == nil || !strings.Contains(err.Error(), "signature") {
+			t.Errorf("tampered %s: expected signature rejection, got %v", name, err)
+		}
+	}
+
+	// A stripped signature is rejected too.
+	h := beginSigned(t, c)
+	h.Signature = ""
+	if err := c.WriteNotify(ctx, h); err == nil || !strings.Contains(err.Error(), "signature required") {
+		t.Errorf("stripped signature: expected 'signature required', got %v", err)
+	}
+
+	// A different deployment secret must not validate this handle.
+	other := newSignedDeadClient(t, "other-secret")
+	h = beginSigned(t, c)
+	if err := other.WriteNotify(ctx, h); err == nil || !strings.Contains(err.Error(), "invalid handle signature") {
+		t.Errorf("cross-secret: expected invalid signature, got %v", err)
+	}
+}
+
+// TestHandleSignature_IgnoredWithoutSecret: verification is opt-in — a
+// secretless client must not reject a handle for carrying (or lacking) a
+// signature. The structurally valid handle passes every pre-Redis check and
+// fails only at the unreachable Redis, proving the signature field played no
+// part.
+func TestHandleSignature_IgnoredWithoutSecret(t *testing.T) {
+	c := newDeadClient(t)
+	h := &WriteHandle{
+		Catalog: "users", Path: "/", MergeType: MergeTypeReplace, UUID: testUUID,
+		URI:       "mem://data/" + objkey.DeltaPath("users", testUUID),
+		Signature: "bogus-but-ignored",
+	}
+	err := c.WriteNotify(context.Background(), h)
+	if err == nil {
+		t.Fatal("expected an error from the unreachable Redis")
+	}
+	if strings.Contains(err.Error(), "signature") {
+		t.Fatalf("secretless client must ignore the signature, got %v", err)
+	}
+}
+
+// TestHandleSignature_SignedRoundTrip_Redis: the happy path against live
+// Redis — an untampered signed handle notifies and reads back normally.
+func TestHandleSignature_SignedRoundTrip_Redis(t *testing.T) {
+	rdb := redisTestDB(t, 13)
+	prefix := testPrefix(t)
+	cleanupKeys(t, rdb, prefix+":*")
+
+	store := mem.New()
+	resolve := func(_ storage.Kind, _, bucket string) (storage.Storage, error) {
+		return presignBucket{store.Bucket(bucket)}, nil
+	}
+	c := New(prefix, rdb, resolve, WithHandleSecret([]byte("s3cret")))
+
+	ctx := context.Background()
+	h, err := c.WriteBegin(ctx, WriteBeginRequest{
+		Catalog: "users", Path: "/", MergeType: MergeTypeReplace, Provider: "mem", Bucket: "data",
+	})
+	if err != nil {
+		t.Fatalf("WriteBegin: %v", err)
+	}
+	if err := store.Bucket(h.Bucket).Put(ctx, h.Catalog, h.Key, []byte(`{"name":"Alice"}`)); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := c.WriteNotify(ctx, h); err != nil {
+		t.Fatalf("WriteNotify (signed, untampered): %v", err)
+	}
+	got, err := ReadString(ctx, c.List(ctx, "users"))
+	if err != nil {
+		t.Fatalf("ReadString: %v", err)
+	}
+	if gjson.Parse(got).Get("name").String() != "Alice" {
+		t.Fatalf("doc = %s, want name=Alice", got)
+	}
+}

--- a/write_signature_test.go
+++ b/write_signature_test.go
@@ -75,6 +75,20 @@ func TestHandleSignature_RejectsTampering(t *testing.T) {
 	}
 }
 
+// TestHandleSignature_RejectsExpiredHandle: the signature makes ExpiresAt
+// trustworthy, so Notify must also enforce it — a leaked signed handle is
+// not replayable indefinitely. (The handle here is validly signed OVER the
+// past expiry, isolating the expiry check from the tamper check.)
+func TestHandleSignature_RejectsExpiredHandle(t *testing.T) {
+	c := newSignedDeadClient(t, "s3cret")
+	h := beginSigned(t, c)
+	h.ExpiresAt = time.Now().Add(-time.Hour).Unix()
+	h.Signature = c.signHandle(h)
+	if err := c.WriteNotify(context.Background(), h); err == nil || !strings.Contains(err.Error(), "expired") {
+		t.Fatalf("expected expiry rejection, got %v", err)
+	}
+}
+
 // TestHandleSignature_IgnoredWithoutSecret: verification is opt-in — a
 // secretless client must not reject a handle for carrying (or lacking) a
 // signature. The structurally valid handle passes every pre-Redis check and


### PR DESCRIPTION
Implements the three remaining backlog items from the audit rounds. `go vet` / `go test` / `go test -race` all pass; every new behavior is pinned against a live Redis.

## 1. `RemoveDelta(ctx, catalog, tsSeq)` — the poison-delta escape hatch

A delta whose body cannot merge fails **every** read of the catalog; until now the only remedy was hand surgery on the zset (whose member is a JSON string an operator can't realistically reproduce byte-for-byte). `RemoveDelta` takes the exact tsSeq string the merge error prints:

```
merge failed (path=/profile tsSeq=1700000000_42 uri=... type=1): ...
→ removed, err := client.RemoveDelta(ctx, "users", "1700000000_42")
```

The Lua script locates candidates by score and verifies the member's *embedded* tsSeq before ZREMing exactly that member. Index-only — the body object in storage is untouched. Documented as destructive (the removed write disappears from future reads; that's the point).

`TestPoisonBodyFailsLoudly_Redis` now runs the complete operator loop end-to-end: garbage upload → read fails naming the tsSeq → `RemoveDelta` → catalog reads again.

## 2. `InvalidateSamples(ctx, indicator, catalogs...)` — explicit memo invalidation

The memo hash has no TTL, so two cases were previously unreachable: a deleted catalog's memo field lingering forever, and a **loader whose code changed** while the data version didn't (the cached value is now computed wrong, and no staleness policy can tell). One HDEL, returns the count removed. Client-level rather than a `Sampler[T]` method, so ops tooling can sweep without knowing `T`. Indicator/catalog names validated like everywhere else.

Live-Redis test pins the full lifecycle: compute → cached (loader not re-run) → invalidate → recompute.

## 3. `WithHandleSecret(secret)` — opt-in HMAC-signed handles

PR #11's structural check binds a handle's URI to its own (catalog, uuid); the signature completes the story by also pinning **Path / MergeType / ExpiresAt** to what `WriteBegin` issued. HMAC-SHA256 over the identity fields, JSON-array-encoded so no field value can forge a boundary into a neighbour; `WriteNotify` rejects missing or mismatched signatures via constant-time compare, before any Redis call. Without the option nothing changes — the `signature` field is simply absent (`omitempty`).

Tests: per-field tamper rejection (path / mergeType / expiresAt / signature bytes), stripped signature, cross-secret rejection, secretless client ignoring a bogus signature, and a signed round-trip against live Redis.

https://claude.ai/code/session_01VqJozJxfijWpZpmVW53Xac

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqJozJxfijWpZpmVW53Xac)_