### PR TITLE
Project review: hardening fixes, CI, LICENSE, and doc sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+# CI: gofmt + go vet + tests, twice (plain and -race), against a real Redis 7
+# service so the integration tests (which skip without a reachable
+# 127.0.0.1:6379) actually run — including the notify Lua path that only a
+# live Redis exercises.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: gofmt
+        run: |
+          out="$(gofmt -l .)"
+          if [ -n "$out" ]; then
+            echo "gofmt needed on:" && echo "$out" && exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test -count=1 ./...
+
+      - name: go test -race
+        run: go test -count=1 -race ./...

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hkloudou
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -216,9 +216,17 @@ func New(prefix string, rdb *redis.Client, resolve storage.Resolver, opts ...fun
 |--------|-------------|
 | `WithSnapTarget(provider, bucket)` | Where Lake writes auto-generated snapshots. Omit → no auto-snapshotting (reads replay all deltas) |
 | `WithSampleCacheURL(url)` / `WithSampleCacheRedis(rdb)` | Route the Sampler memo hash (`<prefix>:m:*`) to a separate Redis |
+| `WithHandleSecret(secret)` | HMAC-sign every `WriteHandle`; `WriteNotify` then rejects tampered or expired handles (see **Write** below). Every process sharing the prefix needs the same secret |
 | `(*Client) Use(handler EventHandler)` | Register an event handler |
 
-`New` panics on an empty `prefix`, nil `rdb`, or nil `resolve` (programmer error).
+`New` panics on an empty `prefix`, nil `rdb`, or nil `resolve`; option
+constructors panic on invalid input (`WithSnapTarget` on an ambiguous
+provider/bucket, `WithHandleSecret` on an empty secret, `WithSampleCacheURL` on
+a bad URL) — all programmer errors, caught at construction time.
+
+> **Redis compatibility**: developed and tested against Redis 7.x. The notify
+> script calls `TIME` before writing, which relies on effect-based script
+> replication — the default since Redis 5.0 and the only mode since 7.0.
 
 ### Storage
 
@@ -291,10 +299,24 @@ type WriteHandle struct {
     UploadMethod  string            `json:"uploadMethod"`
     UploadHeaders map[string]string `json:"uploadHeaders"`
     ExpiresAt     int64             `json:"expiresAt"` // unix seconds
+    Signature     string            `json:"signature,omitempty"` // set iff WithHandleSecret; echo back unchanged
 }
 ```
 
 **Begin options**: `WithUploadTTL(d)`, `WithUploadContentType(ct)`.
+
+**Handle integrity**: handles round-trip through clients Lake does not trust,
+so `WriteNotify` always re-derives the object path from the handle's own
+`(Catalog, UUID)` and rejects a URI that doesn't match — a tampered handle can
+never point one catalog's index at another catalog's objects. With
+`WithHandleSecret` configured, WriteBegin additionally stamps `Signature`
+(HMAC-SHA256 over the identity fields) and WriteNotify rejects handles whose
+signature is missing/invalid or whose `ExpiresAt` has passed (no indefinite
+replay of a leaked handle).
+
+`Provider` / `Bucket` must be ASCII `[a-zA-Z0-9][a-zA-Z0-9._-]*` — they are
+embedded in the recorded URI, so `/` `:` `|` are rejected at WriteBegin (an
+ambiguous name would make the URI parse back to a different object).
 
 > **Presign capability**: WriteBegin requires the resolved backend to implement
 > `storage.Presigner`. OSS supports it; file / memory return
@@ -390,6 +412,22 @@ err := client.IterateSnaps(ctx, func(catalog string, snap lake.SnapInfo) bool {
     return copyToArchive(ctx, snap.URI) == nil // stop on first failure
 })
 ```
+
+### Operations
+
+| Function | Description |
+|----------|-------------|
+| `(*Client) RemoveDelta(ctx, catalog, tsSeq) (bool, error)` | Remove one poison delta from the index (the body object stays). The **only** correct way to unblock a catalog wedged by an unappliable body |
+| `(*Client) Compact(ctx, catalog) (int64, error)` | Trim the delta zset up to the current snapshot; index-only, safe anytime, no background reaper |
+| `(*Client) InvalidateSamples(ctx, indicator, catalogs...) (int64, error)` | Drop cached samples (e.g. after a loader code change or catalog deletion); next Sample/Batch recomputes |
+
+`RemoveDelta` takes the `tsSeq` string verbatim from the merge error
+(`merge failed (path=… tsSeq=1700000000_42 …)`). It is destructive — the
+removed write disappears from every future read — and it is coherent with
+derived state: the removal bumps the catalog's **removal generation**, so an
+in-flight read that listed the removed delta can neither persist a snapshot
+nor cache a sample computed from pre-removal state. That barrier is exactly
+what a hand-issued `ZREM` would skip.
 
 ## 📖 Core Concepts
 
@@ -517,6 +555,14 @@ client.Use(func(catalog, event string, attrs map[string]any) {
 | `WriteNotify` | `path`, `uri` |
 | `Sample` / `BatchSample` | `indicator` |
 | `SampleCacheError` | `op`, `err` |
+| `InvalidateSample` | `indicator` |
+| `RemoveDelta` | `tsSeq` |
+| `Compact` | — |
+| `SnapshotError` | `stop`, `err` — the async snapshot save failed (it is otherwise invisible: reads never wait for it) |
+
+Events fire at operation **start** (before validation / Redis I/O), so
+handlers observe every attempt; `SampleCacheError` / `SnapshotError` fire when
+the corresponding failure happens.
 
 > For distributed tracing, instrument the Redis / storage clients in your
 > resolver; Lake intentionally avoids dragging in OpenTelemetry.
@@ -555,9 +601,11 @@ a body that cannot be applied (invalid JSON, an RFC 7396 patch that doesn't
 parse) fails merge, and because the same merge gates snapshotting the failure is
 sticky: every read of that catalog errors until the bad delta is removed. There
 is intentionally no read-time skip/quarantine. The merge error names the
-offending delta (`path`, `tsSeq`, `uri`, `catalog`); recovery is manual (`ZREM`
-the member from `{prefix}:d:{catalog}`). Keeping bodies valid before upload is
-the contract.
+offending delta (`path`, `tsSeq`, `uri`, `catalog`); recovery is
+`client.RemoveDelta(ctx, catalog, tsSeq)` — see **Operations** below. (Do NOT
+hand-`ZREM` the member: that bypasses the removal-generation barrier, so an
+in-flight read could persist a snapshot that resurrects the removed write.)
+Keeping bodies valid before upload is the contract.
 
 ### Snapshot save failure is not user-visible
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ func New(prefix string, rdb *redis.Client, resolve storage.Resolver, opts ...fun
 
 | Option | Description |
 |--------|-------------|
-| `WithSnapTarget(provider, bucket)` | Where Lake writes auto-generated snapshots. Omit → no auto-snapshotting (reads replay all deltas) |
+| `WithSnapTarget(provider, bucket)` | Where Lake writes auto-generated snapshots. Omit — or pass both empty — → no auto-snapshotting (reads replay all deltas) |
 | `WithSampleCacheURL(url)` / `WithSampleCacheRedis(rdb)` | Route the Sampler memo hash (`<prefix>:m:*`) to a separate Redis |
 | `WithHandleSecret(secret)` | HMAC-sign every `WriteHandle`; `WriteNotify` then rejects tampered or expired handles (see **Write** below). Every process sharing the prefix needs the same secret |
 | `(*Client) Use(handler EventHandler)` | Register an event handler |
@@ -316,7 +316,9 @@ replay of a leaked handle).
 
 `Provider` / `Bucket` must be ASCII `[a-zA-Z0-9][a-zA-Z0-9._-]*` — they are
 embedded in the recorded URI, so `/` `:` `|` are rejected at WriteBegin (an
-ambiguous name would make the URI parse back to a different object).
+ambiguous name would make the URI parse back to a different object), and
+WriteNotify re-checks the parsed parts of the handle's URI (the handle is
+untrusted input).
 
 > **Presign capability**: WriteBegin requires the resolved backend to implement
 > `storage.Presigner`. OSS supports it; file / memory return
@@ -602,7 +604,8 @@ parse) fails merge, and because the same merge gates snapshotting the failure is
 sticky: every read of that catalog errors until the bad delta is removed. There
 is intentionally no read-time skip/quarantine. The merge error names the
 offending delta (`path`, `tsSeq`, `uri`, `catalog`); recovery is
-`client.RemoveDelta(ctx, catalog, tsSeq)` — see **Operations** below. (Do NOT
+`client.RemoveDelta(ctx, catalog, tsSeq)` — see **Operations** in the API
+reference above. (Do NOT
 hand-`ZREM` the member: that bypasses the removal-generation barrier, so an
 in-flight read could persist a snapshot that resurrects the removed write.)
 Keeping bodies valid before upload is the contract.

--- a/client_test.go
+++ b/client_test.go
@@ -43,3 +43,13 @@ func newDeadClient(t *testing.T) *Client {
 	t.Helper()
 	return newTestClient(unreachableRedis)
 }
+
+// newDeadClientOpts is newDeadClient for tests that need a custom resolver
+// and/or client options (e.g. a failing snap target) instead of the plain
+// mem-backed default.
+func newDeadClientOpts(t *testing.T, resolve storage.Resolver, opts ...func(*option)) *Client {
+	t.Helper()
+	rdb := redis.NewClient(&redis.Options{Addr: unreachableRedis, DialTimeout: 200 * time.Millisecond})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return New("test", rdb, resolve, opts...)
+}

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -31,3 +31,26 @@ func ValidateCatalog(catalog string) error {
 	}
 	return nil
 }
+
+// storagePartRegex: storage provider / bucket name, as embedded in object
+// URIs ("provider://bucket/path"). ParseURI splits a URI on the FIRST "://"
+// and the FIRST "/" after it, so neither part may contain "/" or ":" —
+// otherwise BuildURI/ParseURI disagree and the recorded locator resolves to
+// a different object than the one written. Conservative ASCII charset; no
+// leading "." or "-" (hidden-file / flag conventions, and "-internal"-style
+// endpoint suffixing must not be forgeable via the name).
+var storagePartRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._\-]*$`)
+
+func ValidateStorageProvider(provider string) error {
+	if !storagePartRegex.MatchString(provider) {
+		return fmt.Errorf(`invalid storage provider %q: ASCII [a-zA-Z0-9][a-zA-Z0-9._\-]* required ("/" ":" "|" forbidden)`, provider)
+	}
+	return nil
+}
+
+func ValidateStorageBucket(bucket string) error {
+	if !storagePartRegex.MatchString(bucket) {
+		return fmt.Errorf(`invalid storage bucket %q: ASCII [a-zA-Z0-9][a-zA-Z0-9._\-]* required ("/" ":" "|" forbidden)`, bucket)
+	}
+	return nil
+}

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -42,15 +42,18 @@ func ValidateCatalog(catalog string) error {
 var storagePartRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._\-]*$`)
 
 func ValidateStorageProvider(provider string) error {
-	if !storagePartRegex.MatchString(provider) {
-		return fmt.Errorf(`invalid storage provider %q: ASCII [a-zA-Z0-9][a-zA-Z0-9._\-]* required ("/" ":" "|" forbidden)`, provider)
-	}
-	return nil
+	return validateStoragePart("provider", provider)
 }
 
 func ValidateStorageBucket(bucket string) error {
-	if !storagePartRegex.MatchString(bucket) {
-		return fmt.Errorf(`invalid storage bucket %q: ASCII [a-zA-Z0-9][a-zA-Z0-9._\-]* required ("/" ":" "|" forbidden)`, bucket)
+	return validateStoragePart("bucket", bucket)
+}
+
+// validateStoragePart is the single definition of the URI-part format; the
+// two exported wrappers exist only to name the offending part in the error.
+func validateStoragePart(kind, s string) error {
+	if !storagePartRegex.MatchString(s) {
+		return fmt.Errorf(`invalid storage %s %q: ASCII [a-zA-Z0-9][a-zA-Z0-9._\-]* required ("/" ":" "|" forbidden)`, kind, s)
 	}
 	return nil
 }

--- a/internal/utils/validate_storage_test.go
+++ b/internal/utils/validate_storage_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import "testing"
+
+func TestValidateStorageProviderBucket(t *testing.T) {
+	valid := []string{"oss", "s3", "cos", "mem", "my-bucket", "b.example", "B_2", "0start"}
+	for _, s := range valid {
+		if err := ValidateStorageProvider(s); err != nil {
+			t.Errorf("provider %q: unexpected error: %v", s, err)
+		}
+		if err := ValidateStorageBucket(s); err != nil {
+			t.Errorf("bucket %q: unexpected error: %v", s, err)
+		}
+	}
+
+	// "/" and ":" would desynchronise BuildURI/ParseURI; the rest are the
+	// usual delimiter / convention hazards shared with catalog names.
+	invalid := []string{"", "a/b", "a:b", "a|b", ".hidden", "-flag", "空", "a b", "a\tb"}
+	for _, s := range invalid {
+		if err := ValidateStorageProvider(s); err == nil {
+			t.Errorf("provider %q: expected error, got nil", s)
+		}
+		if err := ValidateStorageBucket(s); err == nil {
+			t.Errorf("bucket %q: expected error, got nil", s)
+		}
+	}
+}

--- a/internal/xsync/singleflight.go
+++ b/internal/xsync/singleflight.go
@@ -7,8 +7,9 @@ import (
 
 // SingleFlight dedupes concurrent calls under the same key — only one
 // invocation of fn runs at a time per key; waiters share its result. If fn
-// panics, the panic propagates to the leader caller and waiters receive an
-// error.
+// does not complete normally (it panics, or exits via runtime.Goexit), the
+// abnormal exit keeps propagating in the leader caller and waiters receive
+// an explicit error.
 type SingleFlight[T any] interface {
 	Do(key string, fn func() (T, error)) (T, error)
 }
@@ -40,19 +41,18 @@ func (g *flightGroup[T]) Do(key string, fn func() (T, error)) (T, error) {
 	g.calls[key] = c
 	g.mu.Unlock()
 
-	// Cleanup must run even if fn panics: otherwise the key stays in the map
-	// and every future waiter blocks on wg forever. The panic still propagates
-	// to this (leader) caller; in-flight waiters get an explicit error — NOT
-	// (zero, nil), which would be indistinguishable from a successful call
-	// that produced the zero value (e.g. an empty cache entry).
+	// Cleanup must run even if fn never returns (panic, or runtime.Goexit —
+	// e.g. a t.Fatalf inside a loader): otherwise the key stays in the map
+	// and every future waiter blocks on wg forever. In both abnormal cases
+	// waiters get an explicit error — NOT (zero, nil), which would be
+	// indistinguishable from a successful call that produced the zero value
+	// (e.g. an empty cache entry). The completed flag, not recover(), detects
+	// this: recover() cannot see a Goexit, and not recovering lets the panic
+	// keep propagating in this (leader) caller unaltered.
+	completed := false
 	defer func() {
-		if r := recover(); r != nil {
-			c.err = fmt.Errorf("xsync: singleflight leader panicked: %v", r)
-			g.mu.Lock()
-			delete(g.calls, key)
-			g.mu.Unlock()
-			c.wg.Done()
-			panic(r)
+		if !completed {
+			c.err = fmt.Errorf("xsync: singleflight leader did not complete (panic or runtime.Goexit)")
 		}
 		g.mu.Lock()
 		delete(g.calls, key)
@@ -61,5 +61,6 @@ func (g *flightGroup[T]) Do(key string, fn func() (T, error)) (T, error) {
 	}()
 
 	c.val, c.err = fn()
+	completed = true
 	return c.val, c.err
 }

--- a/internal/xsync/singleflight.go
+++ b/internal/xsync/singleflight.go
@@ -1,9 +1,14 @@
 package xsync
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // SingleFlight dedupes concurrent calls under the same key — only one
-// invocation of fn runs at a time per key; waiters share its result.
+// invocation of fn runs at a time per key; waiters share its result. If fn
+// panics, the panic propagates to the leader caller and waiters receive an
+// error.
 type SingleFlight[T any] interface {
 	Do(key string, fn func() (T, error)) (T, error)
 }
@@ -37,8 +42,18 @@ func (g *flightGroup[T]) Do(key string, fn func() (T, error)) (T, error) {
 
 	// Cleanup must run even if fn panics: otherwise the key stays in the map
 	// and every future waiter blocks on wg forever. The panic still propagates
-	// to this (leader) caller; in-flight waiters observe the zero value.
+	// to this (leader) caller; in-flight waiters get an explicit error — NOT
+	// (zero, nil), which would be indistinguishable from a successful call
+	// that produced the zero value (e.g. an empty cache entry).
 	defer func() {
+		if r := recover(); r != nil {
+			c.err = fmt.Errorf("xsync: singleflight leader panicked: %v", r)
+			g.mu.Lock()
+			delete(g.calls, key)
+			g.mu.Unlock()
+			c.wg.Done()
+			panic(r)
+		}
 		g.mu.Lock()
 		delete(g.calls, key)
 		g.mu.Unlock()

--- a/internal/xsync/singleflight_test.go
+++ b/internal/xsync/singleflight_test.go
@@ -2,7 +2,9 @@ package xsync
 
 import (
 	"errors"
+	"strings"
 	"testing"
+	"time"
 )
 
 // TestSingleFlight_PanicDoesNotWedgeKey is the regression guard: a fn that
@@ -24,6 +26,49 @@ func TestSingleFlight_PanicDoesNotWedgeKey(t *testing.T) {
 	got, err := g.Do("k", func() (int, error) { return 42, nil })
 	if err != nil || got != 42 {
 		t.Fatalf("after a panicking call, Do(k) = (%d, %v), want (42, nil)", got, err)
+	}
+}
+
+// TestSingleFlight_PanicSurfacesToWaiters: a waiter joined to a leader whose fn
+// panics must observe an ERROR — not (zero, nil), which would be
+// indistinguishable from a successful call that produced the zero value (an
+// empty cache entry, a zero sample). The panic itself still belongs to the
+// leader only.
+func TestSingleFlight_PanicSurfacesToWaiters(t *testing.T) {
+	g := NewSingleFlight[int]()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	go func() { // leader: panics once released
+		defer func() { _ = recover() }()
+		_, _ = g.Do("k", func() (int, error) {
+			close(entered)
+			<-release
+			panic("boom")
+		})
+	}()
+	<-entered
+
+	type result struct {
+		v   int
+		err error
+	}
+	done := make(chan result, 1)
+	go func() { // waiter: joins the in-flight call
+		v, err := g.Do("k", func() (int, error) {
+			t.Error("waiter must join the leader's flight, not run its own fn")
+			return -1, nil
+		})
+		done <- result{v, err}
+	}()
+	// Give the waiter time to register on the in-flight call before the
+	// leader panics; if it were somehow late, its own fn would t.Error above.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	res := <-done
+	if res.err == nil || !strings.Contains(res.err.Error(), "panicked") {
+		t.Fatalf("waiter got (%d, %v), want a leader-panicked error", res.v, res.err)
 	}
 }
 

--- a/internal/xsync/singleflight_test.go
+++ b/internal/xsync/singleflight_test.go
@@ -2,6 +2,8 @@ package xsync
 
 import (
 	"errors"
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -29,47 +31,72 @@ func TestSingleFlight_PanicDoesNotWedgeKey(t *testing.T) {
 	}
 }
 
-// TestSingleFlight_PanicSurfacesToWaiters: a waiter joined to a leader whose fn
-// panics must observe an ERROR — not (zero, nil), which would be
-// indistinguishable from a successful call that produced the zero value (an
-// empty cache entry, a zero sample). The panic itself still belongs to the
-// leader only.
-func TestSingleFlight_PanicSurfacesToWaiters(t *testing.T) {
+// testAbnormalLeaderSurfacesErrorToWaiters: a waiter joined to a leader whose
+// fn never returns (panic or runtime.Goexit) must observe an ERROR — not
+// (zero, nil), which would be indistinguishable from a successful call that
+// produced the zero value (an empty cache entry, a zero sample). The abnormal
+// exit itself still belongs to the leader only.
+//
+// The waiter's registration cannot be observed from outside, so the test
+// retries the interleaving with a fresh key until the waiter actually joins
+// the in-flight call (detected via its fallback fn NOT running) — a lost race
+// retries instead of flaking on a starved CI runner.
+func testAbnormalLeaderSurfacesErrorToWaiters(t *testing.T, abort func()) {
+	t.Helper()
 	g := NewSingleFlight[int]()
 
-	entered := make(chan struct{})
-	release := make(chan struct{})
-	go func() { // leader: panics once released
-		defer func() { _ = recover() }()
-		_, _ = g.Do("k", func() (int, error) {
-			close(entered)
-			<-release
-			panic("boom")
-		})
-	}()
-	<-entered
+	for attempt := 0; attempt < 100; attempt++ {
+		key := fmt.Sprintf("k%d", attempt)
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		go func() { // leader: exits abnormally once released
+			defer func() { _ = recover() }()
+			_, _ = g.Do(key, func() (int, error) {
+				close(entered)
+				<-release
+				abort()
+				return 0, nil // unreachable
+			})
+		}()
+		<-entered
 
-	type result struct {
-		v   int
-		err error
-	}
-	done := make(chan result, 1)
-	go func() { // waiter: joins the in-flight call
-		v, err := g.Do("k", func() (int, error) {
-			t.Error("waiter must join the leader's flight, not run its own fn")
-			return -1, nil
-		})
-		done <- result{v, err}
-	}()
-	// Give the waiter time to register on the in-flight call before the
-	// leader panics; if it were somehow late, its own fn would t.Error above.
-	time.Sleep(50 * time.Millisecond)
-	close(release)
+		type result struct {
+			v     int
+			err   error
+			ownFn bool
+		}
+		done := make(chan result, 1)
+		go func() { // waiter: tries to join the in-flight call
+			own := false
+			v, err := g.Do(key, func() (int, error) {
+				own = true // lost the race: the leader was already gone
+				return -1, nil
+			})
+			done <- result{v, err, own}
+		}()
+		time.Sleep(10 * time.Millisecond) // best-effort; a missed join just retries
+		close(release)
 
-	res := <-done
-	if res.err == nil || !strings.Contains(res.err.Error(), "panicked") {
-		t.Fatalf("waiter got (%d, %v), want a leader-panicked error", res.v, res.err)
+		res := <-done
+		if res.ownFn {
+			continue // waiter never joined this flight; retry with a fresh key
+		}
+		if res.err == nil || !strings.Contains(res.err.Error(), "did not complete") {
+			t.Fatalf("waiter got (%d, %v), want a leader-did-not-complete error", res.v, res.err)
+		}
+		return
 	}
+	t.Fatal("waiter never joined the leader's flight in 100 attempts")
+}
+
+func TestSingleFlight_PanicSurfacesErrorToWaiters(t *testing.T) {
+	testAbnormalLeaderSurfacesErrorToWaiters(t, func() { panic("boom") })
+}
+
+// runtime.Goexit is the t.Fatalf path: a loader calling t.Fatalf inside a
+// test must not hand concurrent waiters a phantom (zero, nil) success.
+func TestSingleFlight_GoexitSurfacesErrorToWaiters(t *testing.T) {
+	testAbnormalLeaderSurfacesErrorToWaiters(t, runtime.Goexit)
 }
 
 // TestSingleFlight_ReturnsValueAndError covers the plain passthrough: Do returns

--- a/lake.go
+++ b/lake.go
@@ -95,16 +95,22 @@ func New(prefix string, rdb *redis.Client, resolve storage.Resolver, opts ...fun
 }
 
 // WithSnapTarget sets where Lake writes the snapshots it auto-generates on the
-// read path (resolved via the client's Resolver). Omit it to disable
-// auto-snapshotting: reads then replay all deltas from "{}" — correct, just
-// slower for long histories.
+// read path (resolved via the client's Resolver). Omit it — or pass both
+// arguments empty — to disable auto-snapshotting: reads then replay all
+// deltas from "{}" — correct, just slower for long histories. (Both-empty
+// stays a valid "disabled" spelling so config-driven callers can pass unset
+// values through.)
 //
 // Panics on an invalid provider/bucket (programmer error at construction
 // time): both are embedded in every snapshot's URI (provider://bucket/path),
 // and a "/" or ":" inside either part would make the recorded locator parse
 // back to a different bucket — every read of a snapshotted catalog would
-// then fail.
+// then fail. One-empty-one-set is also a panic: it silently disabled
+// snapshotting before, which can only be a config mistake.
 func WithSnapTarget(provider, bucket string) func(*option) {
+	if provider == "" && bucket == "" {
+		return func(*option) {} // explicit "disabled"
+	}
 	if err := utils.ValidateStorageProvider(provider); err != nil {
 		panic(fmt.Errorf("lake: WithSnapTarget: %w", err))
 	}

--- a/lake.go
+++ b/lake.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/hkloudou/lake/v3/internal/index"
+	"github.com/hkloudou/lake/v3/internal/utils"
 	"github.com/hkloudou/lake/v3/internal/xsync"
 	"github.com/hkloudou/lake/v3/storage"
 	"github.com/redis/go-redis/v9"
@@ -97,7 +98,19 @@ func New(prefix string, rdb *redis.Client, resolve storage.Resolver, opts ...fun
 // read path (resolved via the client's Resolver). Omit it to disable
 // auto-snapshotting: reads then replay all deltas from "{}" — correct, just
 // slower for long histories.
+//
+// Panics on an invalid provider/bucket (programmer error at construction
+// time): both are embedded in every snapshot's URI (provider://bucket/path),
+// and a "/" or ":" inside either part would make the recorded locator parse
+// back to a different bucket — every read of a snapshotted catalog would
+// then fail.
 func WithSnapTarget(provider, bucket string) func(*option) {
+	if err := utils.ValidateStorageProvider(provider); err != nil {
+		panic(fmt.Errorf("lake: WithSnapTarget: %w", err))
+	}
+	if err := utils.ValidateStorageBucket(bucket); err != nil {
+		panic(fmt.Errorf("lake: WithSnapTarget: %w", err))
+	}
 	return func(o *option) { o.snapProvider, o.snapBucket = provider, bucket }
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -1,6 +1,11 @@
 package lake
 
 // EventHandler is invoked around Lake operations for logging / monitoring.
+//
+// Handlers must be safe for concurrent use and should be fast and not panic:
+// some events fire from Lake-internal goroutines — Batch loader workers
+// (SampleCacheError) and the async snapshot saver (SnapshotError), the latter
+// possibly after the triggering Read has already returned.
 type EventHandler func(catalog, event string, attrs map[string]any)
 
 // Use registers an event handler; handlers run in registration order. Call it

--- a/read.go
+++ b/read.go
@@ -57,7 +57,16 @@ func (c *Client) readData(ctx context.Context, list *ListResult) ([]byte, error)
 	if c.snapProvider != "" {
 		if next := list.NextSnap(); next != nil {
 			snapData := append([]byte(nil), resultData...)
-			go c.saveSnapshot(context.Background(), list.catalog, next.StopTsSeq, list.removeGen, snapData)
+			go func() {
+				// This goroutine outlives the read and has no caller to
+				// recover a panic (from a storage backend, or a user event
+				// handler fired on the failure path) — without this guard a
+				// panic here would kill the whole process to save an
+				// optimization. Contained, not silent: saveSnapshot emits
+				// SnapshotError for failures, and the next read regenerates.
+				defer func() { _ = recover() }()
+				_, _ = c.saveSnapshot(context.Background(), list.catalog, next.StopTsSeq, list.removeGen, snapData)
+			}()
 		}
 	}
 	return resultData, nil

--- a/read.go
+++ b/read.go
@@ -57,16 +57,7 @@ func (c *Client) readData(ctx context.Context, list *ListResult) ([]byte, error)
 	if c.snapProvider != "" {
 		if next := list.NextSnap(); next != nil {
 			snapData := append([]byte(nil), resultData...)
-			go func() {
-				// This goroutine outlives the read and has no caller to
-				// recover a panic (from a storage backend, or a user event
-				// handler fired on the failure path) — without this guard a
-				// panic here would kill the whole process to save an
-				// optimization. Contained, not silent: saveSnapshot emits
-				// SnapshotError for failures, and the next read regenerates.
-				defer func() { _ = recover() }()
-				_, _ = c.saveSnapshot(context.Background(), list.catalog, next.StopTsSeq, list.removeGen, snapData)
-			}()
+			go c.saveSnapshotGuarded(list.catalog, next.StopTsSeq, list.removeGen, snapData)
 		}
 	}
 	return resultData, nil

--- a/sample.go
+++ b/sample.go
@@ -252,6 +252,11 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 		for _, cat := range probe {
 			c.emitEvent(cat, "SampleCacheError", map[string]any{"op": "hmget", "err": err.Error()})
 		}
+	}
+	if len(cached) != len(fields) {
+		// Covers the error path above AND any short reply (redis.Nil leaves
+		// cached nil; a misbehaving proxy could truncate): every index below
+		// must be in range, and an all-nil row simply reads as a miss.
 		cached = make([]any, len(fields))
 	}
 	if e, ok := cached[len(probe)].(string); ok {
@@ -437,7 +442,7 @@ func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult
 	}
 	if vals, err := memoCmd.Result(); err != nil {
 		c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hmget", "err": err.Error()})
-	} else {
+	} else if len(vals) == 2 { // guard against a short reply — treat as a miss
 		if e, ok := vals[1].(string); ok {
 			epoch = e
 		}

--- a/sample.go
+++ b/sample.go
@@ -231,11 +231,10 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 	_, _ = pipe.Exec(ctx)
 
 	catGens := make(map[string]string, len(probe))
-	if genVals, err := genCmd.Result(); err == nil && len(genVals) == len(probe) {
-		for i, raw := range genVals {
-			if g, ok := raw.(string); ok {
-				catGens[probe[i]] = g
-			}
+	genVals, _ := genCmd.Result()
+	for i, raw := range hmgetRow(genVals, len(probe)) {
+		if g, ok := raw.(string); ok {
+			catGens[probe[i]] = g
 		}
 	}
 	catGen := func(cat string) string {
@@ -253,12 +252,7 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 			c.emitEvent(cat, "SampleCacheError", map[string]any{"op": "hmget", "err": err.Error()})
 		}
 	}
-	if len(cached) != len(fields) {
-		// Covers the error path above AND any short reply (redis.Nil leaves
-		// cached nil; a misbehaving proxy could truncate): every index below
-		// must be in range, and an all-nil row simply reads as a miss.
-		cached = make([]any, len(fields))
-	}
+	cached = hmgetRow(cached, len(fields))
 	if e, ok := cached[len(probe)].(string); ok {
 		epoch = e
 	}
@@ -440,16 +434,17 @@ func (s *Sampler[T]) sampleCore(ctx context.Context, c *Client, list *ListResult
 	if g, err := genCmd.Result(); err == nil {
 		catGen = g
 	}
-	if vals, err := memoCmd.Result(); err != nil {
-		c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hmget", "err": err.Error()})
-	} else if len(vals) == 2 { // guard against a short reply — treat as a miss
-		if e, ok := vals[1].(string); ok {
-			epoch = e
-		}
-		if cached, ok := vals[0].(string); ok {
-			if meta, data, derr := unmarshalSampleCache[T]([]byte(cached)); derr == nil && !s.isStale(meta, list, peers, now) {
-				return data, nil
-			}
+	vals, verr := memoCmd.Result()
+	if verr != nil {
+		c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hmget", "err": verr.Error()})
+	}
+	vals = hmgetRow(vals, 2)
+	if e, ok := vals[1].(string); ok {
+		epoch = e
+	}
+	if cached, ok := vals[0].(string); ok {
+		if meta, data, derr := unmarshalSampleCache[T]([]byte(cached)); derr == nil && !s.isStale(meta, list, peers, now) {
+			return data, nil
 		}
 	}
 	return s.loadAndCache(ctx, c, list, hashKey, lastUpdated, now, epoch, catGen)
@@ -543,6 +538,19 @@ type loaderError struct{ err error }
 
 func (e *loaderError) Error() string { return e.err.Error() }
 func (e *loaderError) Unwrap() error { return e.err }
+
+// hmgetRow normalizes a pipelined HMGet reply to exactly n entries: an
+// errored, nil, or short reply becomes an all-nil row, so callers can index
+// it unconditionally and absent values read as cache misses. (Redis returns
+// exactly one entry per requested field on success; anything else — a
+// transport error, redis.Nil, a truncating proxy — must degrade to a miss,
+// never an index-out-of-range panic.)
+func hmgetRow(vals []any, n int) []any {
+	if len(vals) != n {
+		return make([]any, n)
+	}
+	return vals
+}
 
 // normalizeGen maps the two spellings of "no removal ever" — a missing/empty
 // generation and the literal "0" — onto one value for comparison.

--- a/snapshot.go
+++ b/snapshot.go
@@ -20,6 +20,28 @@ func (c *Client) IterateSnaps(ctx context.Context, fn func(catalog string, snap 
 	return c.reader.IterateSnaps(ctx, fn)
 }
 
+// saveSnapshotGuarded is the fire-and-forget form of saveSnapshot for the
+// read path's async goroutine. That goroutine outlives the read and has no
+// caller to recover a panic — from a storage backend, or a user event
+// handler fired on the failure path — so an escaped panic would kill the
+// whole process to save an optimization. Contained, not silent: a panic
+// still emits SnapshotError (saveSnapshot's own error emit cannot fire
+// during unwinding — its named err is nil then), and the emit itself is
+// guarded again in case the panicking party IS a handler.
+func (c *Client) saveSnapshotGuarded(catalog string, stop index.TimeSeqID, removeGen string, data []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			defer func() { _ = recover() }() // a panicking handler must not escape either
+			c.emitEvent(catalog, "SnapshotError", map[string]any{
+				"stop": stop.String(), "err": fmt.Sprintf("panic: %v", r),
+			})
+		}
+	}()
+	// Background context: an aborted Read must not cancel a snapshot that
+	// benefits every future reader.
+	_, _ = c.saveSnapshot(context.Background(), catalog, stop, removeGen, data)
+}
+
 // saveSnapshot writes snap bytes to the configured snap target and upserts the
 // Redis hash entry (as [tsSeq, uri]) — monotonically, and only if removeGen
 // still matches the catalog's removal generation: AddSnap drops the upsert if

--- a/snapshot.go
+++ b/snapshot.go
@@ -27,11 +27,20 @@ func (c *Client) IterateSnaps(ctx context.Context, fn func(catalog string, snap 
 // that produced data (which would otherwise resurrect the removed write).
 // No-op when no snap target is configured. SingleFlight on (catalog, stop,
 // gen) dedupes concurrent saves within this process.
+//
+// The read path calls this fire-and-forget, so a failure is user-invisible by
+// design (the next read just regenerates); a "SnapshotError" event is emitted
+// per failed attempt so operators still see a snap target that never works.
 func (c *Client) saveSnapshot(ctx context.Context, catalog string, stop index.TimeSeqID, removeGen string, data []byte) (string, error) {
 	if c.snapProvider == "" || c.snapBucket == "" {
 		return "", nil
 	}
-	return c.snapFlight.Do(fmt.Sprintf("%s_%s_%s", catalog, stop, removeGen), func() (string, error) {
+	return c.snapFlight.Do(fmt.Sprintf("%s_%s_%s", catalog, stop, removeGen), func() (uri string, err error) {
+		defer func() {
+			if err != nil {
+				c.emitEvent(catalog, "SnapshotError", map[string]any{"stop": stop.String(), "err": err.Error()})
+			}
+		}()
 		// The object path must be unique per (stop, removal generation), not
 		// just per stop: removing a non-latest delta leaves the stop
 		// unchanged, and if both generations shared one path, the stale
@@ -53,7 +62,7 @@ func (c *Client) saveSnapshot(ctx context.Context, catalog string, stop index.Ti
 		if err := st.Put(ctx, catalog, path, data); err != nil {
 			return "", fmt.Errorf("save snapshot: %w", err)
 		}
-		uri := objkey.BuildURI(c.snapProvider, c.snapBucket, path)
+		uri = objkey.BuildURI(c.snapProvider, c.snapBucket, path)
 		if err := c.writer.AddSnap(ctx, catalog, stop, uri, removeGen); err != nil {
 			return "", fmt.Errorf("index snapshot: %w", err)
 		}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,0 +1,34 @@
+package lake
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hkloudou/lake/v3/storage"
+	"github.com/redis/go-redis/v9"
+)
+
+// TestSaveSnapshot_EmitsSnapshotErrorEvent: the snapshot save runs
+// fire-and-forget off the read path, so its error never reaches a caller —
+// the SnapshotError event is the only way an operator can notice a snap
+// target that never works (bad credentials, missing bucket, down store).
+func TestSaveSnapshot_EmitsSnapshotErrorEvent(t *testing.T) {
+	resolve := func(_ storage.Kind, _, _ string) (storage.Storage, error) {
+		return nil, errIntentional // every resolution fails, incl. the snap target
+	}
+	rdb := redis.NewClient(&redis.Options{Addr: unreachableRedis, DialTimeout: 200 * time.Millisecond})
+	t.Cleanup(func() { _ = rdb.Close() })
+	c := New("snaperrtest", rdb, resolve, WithSnapTarget("mem", "snaps"))
+	spy := &spyHandler{}
+	c.Use(spy.handler())
+
+	_, err := c.saveSnapshot(context.Background(), "users",
+		TimeSeqID{Timestamp: 1700000000, SeqID: 1}, "0", []byte("{}"))
+	if err == nil {
+		t.Fatal("expected saveSnapshot error, got nil")
+	}
+	if !spy.seen("SnapshotError") {
+		t.Fatal("SnapshotError event must be emitted when the snapshot save fails")
+	}
+}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -28,3 +28,25 @@ func TestSaveSnapshot_EmitsSnapshotErrorEvent(t *testing.T) {
 		t.Fatal("SnapshotError event must be emitted when the snapshot save fails")
 	}
 }
+
+// TestSaveSnapshotGuarded_PanicIsContainedAndObservable: a snap backend that
+// PANICS (rather than returning an error) unwinds past saveSnapshot's
+// error-emit (named err is nil during unwinding). The guarded wrapper must
+// both contain the panic — it runs on a goroutine nothing can recover — and
+// still emit SnapshotError, or a panicking snap target would fail forever
+// with zero signal.
+func TestSaveSnapshotGuarded_PanicIsContainedAndObservable(t *testing.T) {
+	resolve := func(_ storage.Kind, _, _ string) (storage.Storage, error) {
+		panic("resolver boom")
+	}
+	c := newDeadClientOpts(t, resolve, WithSnapTarget("mem", "snaps"))
+	spy := &spyHandler{}
+	c.Use(spy.handler())
+
+	// Must not panic the caller (stands in for the detached goroutine).
+	c.saveSnapshotGuarded("users", TimeSeqID{Timestamp: 1700000000, SeqID: 1}, "0", []byte("{}"))
+
+	if !spy.seen("SnapshotError") {
+		t.Fatal("SnapshotError event must be emitted when the snapshot save panics")
+	}
+}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -3,10 +3,8 @@ package lake
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/hkloudou/lake/v3/storage"
-	"github.com/redis/go-redis/v9"
 )
 
 // TestSaveSnapshot_EmitsSnapshotErrorEvent: the snapshot save runs
@@ -17,9 +15,7 @@ func TestSaveSnapshot_EmitsSnapshotErrorEvent(t *testing.T) {
 	resolve := func(_ storage.Kind, _, _ string) (storage.Storage, error) {
 		return nil, errIntentional // every resolution fails, incl. the snap target
 	}
-	rdb := redis.NewClient(&redis.Options{Addr: unreachableRedis, DialTimeout: 200 * time.Millisecond})
-	t.Cleanup(func() { _ = rdb.Close() })
-	c := New("snaperrtest", rdb, resolve, WithSnapTarget("mem", "snaps"))
+	c := newDeadClientOpts(t, resolve, WithSnapTarget("mem", "snaps"))
 	spy := &spyHandler{}
 	c.Use(spy.handler())
 

--- a/storage/cached/redis.go
+++ b/storage/cached/redis.go
@@ -26,9 +26,9 @@ func NewRedisCache(client *redis.Client, ttl time.Duration) *RedisCache {
 	}
 }
 
-// NewRedisCacheWithURL builds a RedisCache from a URL.
-func NewRedisCacheWithURL(metaUrl string, ttl time.Duration) (*RedisCache, error) {
-	opt, err := redis.ParseURL(metaUrl)
+// NewRedisCacheWithURL builds a RedisCache from a Redis URL.
+func NewRedisCacheWithURL(url string, ttl time.Duration) (*RedisCache, error) {
+	opt, err := redis.ParseURL(url)
 	if err != nil {
 		return nil, err
 	}
@@ -77,6 +77,7 @@ func (c *RedisCache) Set(ctx context.Context, namespace, key string, data []byte
 func (c *RedisCache) write(ctx context.Context, cacheKey string, data []byte) {
 	enc, gerr := gzipCompress(data)
 	if gerr != nil {
+		log.Printf("[lake cache] gzip %s: %v", cacheKey, gerr)
 		return
 	}
 	if err := c.client.Set(ctx, cacheKey, enc, c.ttl).Err(); err != nil {

--- a/write.go
+++ b/write.go
@@ -214,8 +214,18 @@ func (c *Client) WriteNotify(ctx context.Context, h *WriteHandle) error {
 	if h.URI == "" {
 		return errors.New("empty URI in handle")
 	}
-	_, _, path, err := objkey.ParseURI(h.URI)
+	provider, bucket, path, err := objkey.ParseURI(h.URI)
 	if err != nil {
+		return err
+	}
+	// The URI round-trips through untrusted clients and is recorded verbatim
+	// into the index, where reads feed its provider/bucket to the resolver —
+	// so hold both to the same charset WriteBegin enforces. ParseURI alone
+	// would accept e.g. bucket "da|ta", which WriteBegin can never emit.
+	if err := utils.ValidateStorageProvider(provider); err != nil {
+		return err
+	}
+	if err := utils.ValidateStorageBucket(bucket); err != nil {
 		return err
 	}
 	if want := objkey.DeltaPath(h.Catalog, h.UUID); path != want {

--- a/write.go
+++ b/write.go
@@ -98,6 +98,15 @@ func (c *Client) WriteBegin(ctx context.Context, req WriteBeginRequest, opts ...
 	if req.Provider == "" || req.Bucket == "" {
 		return nil, errors.New("WriteBegin requires Provider and Bucket")
 	}
+	// Provider/Bucket are embedded in the delta URI (provider://bucket/path);
+	// an ambiguous character ("/", ":") would make ParseURI resolve the
+	// recorded locator to a different object than the one presigned here.
+	if err := utils.ValidateStorageProvider(req.Provider); err != nil {
+		return nil, err
+	}
+	if err := utils.ValidateStorageBucket(req.Bucket); err != nil {
+		return nil, err
+	}
 
 	st, err := c.storageFor(storage.Delta, req.Provider, req.Bucket)
 	if err != nil {

--- a/write_validation_test.go
+++ b/write_validation_test.go
@@ -93,6 +93,54 @@ func TestWriteNotify_RejectsForeignURI(t *testing.T) {
 	}
 }
 
+// TestWriteBegin_RejectsAmbiguousProviderBucket: provider and bucket are
+// embedded in the delta URI "provider://bucket/path", which ParseURI splits
+// on the first "://" and the first "/" — a "/" or ":" inside either part
+// would make the recorded locator resolve to a different object than the one
+// presigned. WriteBegin must reject such names before presigning anything.
+func TestWriteBegin_RejectsAmbiguousProviderBucket(t *testing.T) {
+	c := newDeadClient(t)
+	for _, tc := range []struct{ provider, bucket string }{
+		{"oss/x", "data"},   // "/" in provider
+		{"oss:x", "data"},   // ":" in provider (would nest into "://")
+		{"oss", "data/sub"}, // "/" in bucket → ParseURI eats it as path
+		{"oss", "data:1"},   // ":" in bucket
+		{"oss", "da|ta"},    // delta-member delimiter
+		{".oss", "data"},    // leading dot
+		{"oss", "-data"},    // leading dash
+	} {
+		_, err := c.WriteBegin(context.Background(), WriteBeginRequest{
+			Catalog: "users", Path: "/", MergeType: MergeTypeReplace,
+			Provider: tc.provider, Bucket: tc.bucket,
+		})
+		if err == nil || !strings.Contains(err.Error(), "invalid storage") {
+			t.Fatalf("provider=%q bucket=%q: expected invalid storage error, got %v", tc.provider, tc.bucket, err)
+		}
+	}
+}
+
+// TestWithSnapTarget_PanicsOnAmbiguousTarget: an invalid snap target is a
+// construction-time programmer error (package policy: panic). Catching it at
+// New matters because a snap URI that parses back to a different bucket
+// would wedge every read of a snapshotted catalog at runtime.
+func TestWithSnapTarget_PanicsOnAmbiguousTarget(t *testing.T) {
+	for _, tc := range []struct{ provider, bucket string }{
+		{"oss", "bucket/sub"},
+		{"os:s", "bucket"},
+		{"", "bucket"},
+		{"oss", ""},
+	} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("WithSnapTarget(%q, %q) must panic", tc.provider, tc.bucket)
+				}
+			}()
+			WithSnapTarget(tc.provider, tc.bucket)
+		}()
+	}
+}
+
 func TestWriteBegin_ZeroTTLUsesDefaultTTL(t *testing.T) {
 	store := mem.New()
 	resolve := func(_ storage.Kind, _, bucket string) (storage.Storage, error) {

--- a/write_validation_test.go
+++ b/write_validation_test.go
@@ -119,10 +119,34 @@ func TestWriteBegin_RejectsAmbiguousProviderBucket(t *testing.T) {
 	}
 }
 
+// TestWriteNotify_RejectsAmbiguousURIParts: the handle URI is untrusted
+// input recorded verbatim into the index, where reads feed its parsed
+// provider/bucket to the resolver — so notify holds both to WriteBegin's
+// charset even when the path component binds correctly.
+func TestWriteNotify_RejectsAmbiguousURIParts(t *testing.T) {
+	c := newDeadClient(t)
+	for _, uri := range []string{
+		"me:m://data/" + objkey.DeltaPath("users", testUUID), // ":" in provider
+		"mem://da|ta/" + objkey.DeltaPath("users", testUUID), // "|" in bucket
+	} {
+		err := c.WriteNotify(context.Background(), &WriteHandle{
+			Catalog:   "users",
+			Path:      "/",
+			MergeType: MergeTypeReplace,
+			UUID:      testUUID,
+			URI:       uri,
+		})
+		if err == nil || !strings.Contains(err.Error(), "invalid storage") {
+			t.Fatalf("uri %q: expected invalid storage error, got %v", uri, err)
+		}
+	}
+}
+
 // TestWithSnapTarget_PanicsOnAmbiguousTarget: an invalid snap target is a
 // construction-time programmer error (package policy: panic). Catching it at
 // New matters because a snap URI that parses back to a different bucket
-// would wedge every read of a snapshotted catalog at runtime.
+// would wedge every read of a snapshotted catalog at runtime. Both-empty is
+// the documented "disabled" spelling and must NOT panic; one-empty must.
 func TestWithSnapTarget_PanicsOnAmbiguousTarget(t *testing.T) {
 	for _, tc := range []struct{ provider, bucket string }{
 		{"oss", "bucket/sub"},
@@ -138,6 +162,14 @@ func TestWithSnapTarget_PanicsOnAmbiguousTarget(t *testing.T) {
 			}()
 			WithSnapTarget(tc.provider, tc.bucket)
 		}()
+	}
+
+	// Both-empty = "auto-snapshotting disabled": stays valid for callers that
+	// pass unset config through; the option must be a no-op, not a panic.
+	opt := &option{}
+	WithSnapTarget("", "")(opt)
+	if opt.snapProvider != "" || opt.snapBucket != "" {
+		t.Fatalf("WithSnapTarget(\"\", \"\") must leave the target unset, got %q/%q", opt.snapProvider, opt.snapBucket)
 	}
 }
 


### PR DESCRIPTION
## Why

A front-to-back review of the v3 codebase (core, `internal/*`, `storage/*`, tests, docs). The library's correctness core (atomic list script, removal generations, sample barriers) held up well under review; what this PR fixes is the layer around it: silent failure paths, two latent panics, URI-ambiguity hardening, and repo hygiene (no LICENSE, no CI, drifted README).

## Correctness / hardening

1. **`internal/xsync`: singleflight waiters no longer see a leader panic as success.**
   Previously, if the leader's `fn` panicked, waiters joined to the same key observed `(zero value, nil error)` — indistinguishable from a successful call that produced the zero value (e.g. an empty cache entry or empty snapshot bytes). Waiters now get an explicit error; the panic still propagates to the leader. Regression test included.

2. **`sample.go`: two latent index-out-of-range panics on short HMGET replies.**
   `Batch` indexed `cached[len(probe)]` after a guard that explicitly tolerates `redis.Nil` — but in exactly that case `cached` would be nil → panic. Both `Batch` and `sampleCore` now length-normalize the reply before indexing (short/errored replies read as misses, matching the existing degrade-to-recompute policy).

3. **`WriteBegin` / `WithSnapTarget`: reject ambiguous provider/bucket names.**
   Provider and bucket are embedded in each delta/snap URI (`provider://bucket/path`), and `ParseURI` splits on the first `://` and first `/`. A bucket containing `/` (or provider containing `:`) produces a URI that parses back to a *different* object:
   - for deltas this surfaced as a confusing late mismatch error at `WriteNotify`;
   - for the snap target it was worse — the async save would record a snap URI that resolves to the wrong bucket, wedging **every future read** of a snapshotted catalog.
   `WriteBegin` now validates both (error), `WithSnapTarget` validates at construction (panic, per the package's programmer-error policy). Charset: ASCII `[a-zA-Z0-9][a-zA-Z0-9._-]*`, which all real OSS/S3-style names satisfy.

4. **`snapshot.go`: async snapshot save failures are now observable.**
   The save runs fire-and-forget off the read path (by design), but its error was discarded entirely — a snap target with bad credentials would fail forever with zero signal. A `SnapshotError` event now fires per failed attempt through the existing middleware.

5. **`storage/cached`: log gzip-compress failures** (previously the cache write was silently skipped, inconsistent with the logged Set failure); rename a leftover v2 `metaUrl` param.

## Repo hygiene

6. **LICENSE (MIT) added** — README already declared MIT and linked to `LICENSE` (dead link, dead badge until now).
7. **CI added** (`.github/workflows/ci.yml`): gofmt + `go vet` + `go test` + `go test -race`, with a Redis 7 service container so the integration tests (which skip without a reachable `127.0.0.1:6379`) actually run — including the notify-Lua path only a live Redis exercises.

## Docs (README)

8. **Removed harmful stale advice**: the "poison delta" section still told operators to hand-`ZREM` the bad member — that bypasses the removal-generation barrier that `RemoveDelta` installs, so an in-flight read could persist a snapshot resurrecting the removed write. It now points at `RemoveDelta` and explains why manual `ZREM` is wrong.
9. Documented the previously-invisible surfaces: `WithHandleSecret` (+ `WriteHandle.Signature`), a new **Operations** section (`RemoveDelta` / `Compact` / `InvalidateSamples`), the missing events (`InvalidateSample`, `RemoveDelta`, `Compact`, new `SnapshotError`), and a Redis version compatibility note (the notify script calls `TIME` before writing → needs effect-based script replication: default since Redis 5.0, only mode since 7.0).

## Verification

- `gofmt -l .` clean, `go vet ./...` clean
- `go test -count=1 ./...` and `go test -count=1 -race ./...` pass **with a live local Redis** (integration tests exercised, not skipped)
- New tests: singleflight waiter-error-on-panic; WriteBegin ambiguous provider/bucket rejection; WithSnapTarget panic; storage-name validator unit tests; SnapshotError event emission

## Deliberately out of scope (follow-ups)

- Dependency bumps (`gjson` v1.14.2 et al.) — separate PR so behavior changes are isolated
- `notifyScript` declares the catalog name as `KEYS[1]` (it is not a real key) and computes the seqid key dynamically — harmless on standalone Redis, but worth a doc note that Redis Cluster is unsupported
- `WriteNotify` could return the allocated `tsSeq` (useful for logs / read-your-write); API addition to discuss

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9Bhw6wPJ4hNcWT517wy4w