### PR TITLE
Pin the objkey data spec with tests; document the Redis Cluster limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,11 @@ a bad URL) — all programmer errors, caught at construction time.
 > **Redis compatibility**: developed and tested against Redis 7.x. The notify
 > script calls `TIME` before writing, which relies on effect-based script
 > replication — the default since Redis 5.0 and the only mode since 7.0.
+> **Redis Cluster is not supported** for the index: the scripts operate on
+> multiple keys per catalog (snap hash + delta zset) and derive the seqid
+> counter key inside Lua, which cluster's one-slot-per-script rule rejects.
+> Use a standalone / primary-replica (Sentinel) index Redis; the cache tier
+> (`storage/cached`) has no such constraint.
 
 ### Storage
 

--- a/internal/objkey/objkey_test.go
+++ b/internal/objkey/objkey_test.go
@@ -1,0 +1,77 @@
+package objkey
+
+import (
+	"strings"
+	"testing"
+)
+
+// The object path and URI shapes are part of Lake's DATA SPEC: every recorded
+// delta/snap URI must stay fetchable by future versions (and by plain
+// S3/OSS tooling), so these tests pin the exact rendered forms — a change
+// that breaks one of them breaks already-written deployments.
+
+func TestDeltaAndSnapPathShape(t *testing.T) {
+	// md5("users") = 9bc65c2abec141778ffaa729489f3e87 → shard "9bc6";
+	// pure-lowercase catalog → "(users".
+	const uuid = "0123456789abcdef0123456789abcdef"
+	if got, want := DeltaPath("users", uuid), "9bc6/(users/"+uuid+".dat"; got != want {
+		t.Fatalf("DeltaPath = %q, want %q", got, want)
+	}
+	if got, want := SnapPath("users", "1700000000_42"), "9bc6/(users/1700000000_42.snap"; got != want {
+		t.Fatalf("SnapPath = %q, want %q", got, want)
+	}
+}
+
+func TestCatalogEncodingForms(t *testing.T) {
+	cases := []struct {
+		catalog string
+		enc     string // the encoded segment (2nd path element)
+	}{
+		{"users", "(users"},         // pure lowercase → "(" prefix
+		{"USERS", ")USERS"},         // pure uppercase → ")" prefix
+		{"a-b_c/d.e", "(a-b_c/d.e"}, // lowercase incl. - _ / . stays readable
+		{"Users", "kvzwk4tt"},       // mixed case → lowercased base32, no padding
+		{"u2", "(u2"},               // digits are case-safe
+	}
+	for _, tc := range cases {
+		path := DeltaPath(tc.catalog, "0123456789abcdef0123456789abcdef")
+		parts := strings.SplitN(path, "/", 2)
+		rest := parts[1]
+		if !strings.HasPrefix(rest, tc.enc+"/") {
+			t.Errorf("catalog %q: encoded path %q, want segment %q", tc.catalog, rest, tc.enc)
+		}
+	}
+
+	// The three forms must never collide: "(x" / ")X" markers are forbidden
+	// inside catalog names by ValidateCatalog, and base32 output is bare
+	// lowercase alphanumerics (no marker).
+	if DeltaPath("users", "u") == DeltaPath("USERS", "u") {
+		t.Fatal("lower/upper encodings must not collide")
+	}
+}
+
+func TestBuildParseURIRoundTrip(t *testing.T) {
+	uri := BuildURI("oss", "my-bucket", "9bc6/(users/x.dat")
+	if uri != "oss://my-bucket/9bc6/(users/x.dat" {
+		t.Fatalf("BuildURI = %q", uri)
+	}
+	p, b, path, err := ParseURI(uri)
+	if err != nil || p != "oss" || b != "my-bucket" || path != "9bc6/(users/x.dat" {
+		t.Fatalf("ParseURI = (%q,%q,%q,%v)", p, b, path, err)
+	}
+}
+
+func TestParseURIRejectsMalformed(t *testing.T) {
+	for _, uri := range []string{
+		"",                 // empty
+		"oss://",           // no bucket/path
+		"oss://bucket",     // no path
+		"://bucket/path",   // empty provider
+		"oss:/bucket/path", // not a "://"
+		"bucket/path",      // no scheme at all
+	} {
+		if _, _, _, err := ParseURI(uri); err == nil {
+			t.Errorf("ParseURI(%q): expected error, got nil", uri)
+		}
+	}
+}


### PR DESCRIPTION
Round 3 (final planned round) of the project review, after #15 (hardening/CI/LICENSE/docs) and #16 (dependency upgrades).

## What

1. **`internal/objkey` gets its first tests — pinning the on-disk data spec.**
   This package renders the object paths and URIs (`{md5[0:4]}/{enc(catalog)}/{uuid}.dat`, `provider://bucket/path`) that every recorded delta and snapshot depends on *forever*. It had zero tests, so a well-meaning refactor could silently re-shape paths and orphan existing deployments' data. The new tests pin: the md5 shard + three catalog encoding forms (`(users` / `)USERS` / lowercased base32 for mixed case), delta/snap path shapes, `BuildURI`/`ParseURI` round-trip, and `ParseURI` rejections. Expected values were computed independently and verified before being written down.

2. **README: state the Redis Cluster limitation explicitly.**
   The index scripts operate on multiple keys per catalog (snap hash + delta zset) and derive the per-second seqid counter key *inside* Lua — both incompatible with Cluster's one-slot-per-script rule. The compatibility note now says so, and clarifies the cache tier has no such constraint. Better an explicit "not supported" than a runtime `CROSSSLOT` surprise.

## Verification

- `gofmt` / `go vet` clean; full suite + `-race` green against live Redis 7 (integration tests exercised)
- New objkey tests pass with pre-verified expected values

## After this

With #15 + #16 + this, the review has covered: correctness hardening, silent-failure elimination, repo hygiene (LICENSE/CI), doc drift, dependency/vuln hygiene, and data-spec pinning. Remaining ideas (returning the allocated `tsSeq` from `WriteNotify`, `storage/oss` integration tests) are API-design or credential-bound topics for the maintainer rather than review defects — listed for the record, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9Bhw6wPJ4hNcWT517wy4w

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9Bhw6wPJ4hNcWT517wy4w)_