### PR TITLE
perf: EVALSHA script dispatch; fix: identifier length caps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # The service Redis below is dedicated to this job, so the one test
+      # that issues a server-wide SCRIPT FLUSH may run here (it is skipped
+      # by default to keep `go test ./...` safe against a shared Redis).
+      LAKE_TEST_SCRIPT_FLUSH: "1"
     services:
       redis:
         image: redis:7-alpine

--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ a bad URL) — all programmer errors, caught at construction time.
 > replication — the default since Redis 5.0 and the only mode since 7.0.
 > Scripts are dispatched by `EVALSHA` with an automatic full-body `EVAL`
 > fallback (cold script cache, `ERR NOSCRIPT` spellings, or an ACL that
-> denies `EVALSHA`), so only the `EVAL` permission is strictly required —
-> no `SCRIPT LOAD`.
+> denies the `EVALSHA` command itself), so only the `EVAL` permission is
+> strictly required — no `SCRIPT LOAD`. If local SHA-1 is unavailable (Go's
+> `fips140=only` mode) dispatch degrades to plain `EVAL` automatically.
 > **Redis Cluster is not supported** for the index: the scripts operate on
 > multiple keys per catalog (snap hash + delta zset) and derive the seqid
 > counter key inside Lua, which cluster's one-slot-per-script rule rejects.

--- a/README.md
+++ b/README.md
@@ -443,7 +443,8 @@ what a hand-issued `ZREM` would skip.
 - Must start with `/`; must not end with `/`
 - Each segment starts with a letter / `_` / `$` (no leading digit)
 - `/` alone means the whole document
-- At most 512 bytes (the path is recorded verbatim in every delta's index entry)
+- New writes cap the path at 512 bytes (it is recorded verbatim in every
+  delta's index entry); reads accept longer paths recorded before the cap
 
 ### Storage URI
 
@@ -458,10 +459,13 @@ object path is a Lake convention:
 
 For path safety the catalog is encoded: pure-lowercase `users` → `(users`,
 pure-uppercase `USERS` → `)USERS`, mixed / non-ASCII → lowercased base32.
-Catalog validation forbids `:` `|` `(` `)` so the forms never collide, and caps
-names at 128 bytes so the encoded form always fits one path component on every
-backend (the base32 form of 128 bytes is 208 chars, under the 255-byte
-filesystem limit). Sample indicators follow the same rules.
+Catalog validation forbids `:` `|` `(` `)` so the forms never collide, and
+**new writes** cap names at 128 bytes so the encoded form always fits one path
+component on every backend (the base32 form of 128 bytes is 208 chars, under
+the 255-byte filesystem limit). Length caps bind only where a name mints new
+state (WriteBegin / WriteNotify / NewSampler); List, RemoveDelta, Compact and
+the read path accept longer pre-existing names, so tightening a cap can never
+strand persisted data. Sample indicators follow the same rules as catalogs.
 
 ### Three-step direct upload
 
@@ -590,8 +594,11 @@ Integration tests need a reachable Redis at `127.0.0.1:6379` — e.g.
 `LAKE_TEST_REDIS_ADDR=host:port` points. They skip gracefully when it is
 absent, and they are **non-destructive** — each uses a unique key prefix and
 deletes only its own keys on cleanup (never `FLUSHDB`), so it is safe to point
-them at a Redis that holds other data. The notify Lua's cjson-encoded member
-is only exercised end-to-end with Redis present (`TestWriteReadRoundTrip_Redis`).
+them at a Redis that holds other data. The one exception is opt-in: the
+EVALSHA cold-cache test issues a server-wide `SCRIPT FLUSH` and only runs with
+`LAKE_TEST_SCRIPT_FLUSH=1` (CI sets it against its dedicated Redis). The
+notify Lua's cjson-encoded member is only exercised end-to-end with Redis
+present (`TestWriteReadRoundTrip_Redis`).
 
 ## 💡 Design Philosophy
 

--- a/README.md
+++ b/README.md
@@ -319,11 +319,14 @@ never point one catalog's index at another catalog's objects. With
 signature is missing/invalid or whose `ExpiresAt` has passed (no indefinite
 replay of a leaked handle).
 
-`Provider` / `Bucket` must be ASCII `[a-zA-Z0-9][a-zA-Z0-9._-]*`, at most 63
-bytes (the OSS / S3 bucket-name ceiling) — they are embedded in the recorded
-URI, so `/` `:` `|` are rejected at WriteBegin (an ambiguous name would make
-the URI parse back to a different object), and WriteNotify re-checks the
-parsed parts of the handle's URI (the handle is untrusted input).
+`Provider` / `Bucket` must be ASCII `[a-zA-Z0-9][a-zA-Z0-9._-]*`, at most 128
+bytes — Lake's own backend-agnostic sanity bound (both parts are recorded in
+every delta's URI; a bucket is one path component on the file backend). Real
+object stores impose tighter rules of their own (OSS / S3 buckets: 63 chars),
+surfaced by the backend itself. They are embedded in the recorded URI, so `/`
+`:` `|` are rejected at WriteBegin (an ambiguous name would make the URI parse
+back to a different object), and WriteNotify re-checks the parsed parts of the
+handle's URI (the handle is untrusted input).
 
 > **Presign capability**: WriteBegin requires the resolved backend to implement
 > `storage.Presigner`. OSS supports it; file / memory return

--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ a bad URL) — all programmer errors, caught at construction time.
 > **Redis compatibility**: developed and tested against Redis 7.x. The notify
 > script calls `TIME` before writing, which relies on effect-based script
 > replication — the default since Redis 5.0 and the only mode since 7.0.
+> Scripts are dispatched by `EVALSHA` with an automatic full-body `EVAL`
+> fallback (cold script cache, `ERR NOSCRIPT` spellings, or an ACL that
+> denies `EVALSHA`), so only the `EVAL` permission is strictly required —
+> no `SCRIPT LOAD`.
 > **Redis Cluster is not supported** for the index: the scripts operate on
 > multiple keys per catalog (snap hash + delta zset) and derive the seqid
 > counter key inside Lua, which cluster's one-slot-per-script rule rejects.

--- a/README.md
+++ b/README.md
@@ -319,11 +319,11 @@ never point one catalog's index at another catalog's objects. With
 signature is missing/invalid or whose `ExpiresAt` has passed (no indefinite
 replay of a leaked handle).
 
-`Provider` / `Bucket` must be ASCII `[a-zA-Z0-9][a-zA-Z0-9._-]*` — they are
-embedded in the recorded URI, so `/` `:` `|` are rejected at WriteBegin (an
-ambiguous name would make the URI parse back to a different object), and
-WriteNotify re-checks the parsed parts of the handle's URI (the handle is
-untrusted input).
+`Provider` / `Bucket` must be ASCII `[a-zA-Z0-9][a-zA-Z0-9._-]*`, at most 63
+bytes (the OSS / S3 bucket-name ceiling) — they are embedded in the recorded
+URI, so `/` `:` `|` are rejected at WriteBegin (an ambiguous name would make
+the URI parse back to a different object), and WriteNotify re-checks the
+parsed parts of the handle's URI (the handle is untrusted input).
 
 > **Presign capability**: WriteBegin requires the resolved backend to implement
 > `storage.Presigner`. OSS supports it; file / memory return
@@ -443,6 +443,7 @@ what a hand-issued `ZREM` would skip.
 - Must start with `/`; must not end with `/`
 - Each segment starts with a letter / `_` / `$` (no leading digit)
 - `/` alone means the whole document
+- At most 512 bytes (the path is recorded verbatim in every delta's index entry)
 
 ### Storage URI
 
@@ -457,7 +458,10 @@ object path is a Lake convention:
 
 For path safety the catalog is encoded: pure-lowercase `users` → `(users`,
 pure-uppercase `USERS` → `)USERS`, mixed / non-ASCII → lowercased base32.
-Catalog validation forbids `:` `|` `(` `)` so the forms never collide.
+Catalog validation forbids `:` `|` `(` `)` so the forms never collide, and caps
+names at 128 bytes so the encoded form always fits one path component on every
+backend (the base32 form of 128 bytes is 208 chars, under the 255-byte
+filesystem limit). Sample indicators follow the same rules.
 
 ### Three-step direct upload
 
@@ -581,12 +585,13 @@ go test ./...
 go test -count=1 -race ./...
 ```
 
-Integration tests need a reachable Redis at `127.0.0.1:6379`; they skip
-gracefully when it is absent, and they are **non-destructive** — each uses a
-unique key prefix and deletes only its own keys on cleanup (never `FLUSHDB`), so
-it is safe to point them at a Redis that holds other data. The notify Lua's
-cjson-encoded member is only exercised end-to-end with Redis present
-(`TestWriteReadRoundTrip_Redis`).
+Integration tests need a reachable Redis at `127.0.0.1:6379` — e.g.
+`docker run --rm -d -p 6379:6379 redis:7-alpine` — or wherever
+`LAKE_TEST_REDIS_ADDR=host:port` points. They skip gracefully when it is
+absent, and they are **non-destructive** — each uses a unique key prefix and
+deletes only its own keys on cleanup (never `FLUSHDB`), so it is safe to point
+them at a Redis that holds other data. The notify Lua's cjson-encoded member
+is only exercised end-to-end with Redis present (`TestWriteReadRoundTrip_Redis`).
 
 ## 💡 Design Philosophy
 

--- a/integration_helpers_test.go
+++ b/integration_helpers_test.go
@@ -11,12 +11,20 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// Integration tests talk to a developer's real local Redis (127.0.0.1:6379).
+// Integration tests talk to a developer's real Redis — 127.0.0.1:6379 unless
+// LAKE_TEST_REDIS_ADDR points elsewhere (devcontainers, docker-compose hosts).
 // To stay non-destructive they NEVER FlushDB: each test uses a unique key
 // prefix (testPrefix) and registers cleanupKeys to delete only its own keys.
 // Whatever else lives in that logical DB is left untouched.
 
-const testRedisAddr = "127.0.0.1:6379"
+var testRedisAddr = testRedisAddrFromEnv()
+
+func testRedisAddrFromEnv() string {
+	if a := os.Getenv("LAKE_TEST_REDIS_ADDR"); a != "" {
+		return a
+	}
+	return "127.0.0.1:6379"
+}
 
 // redisTestDB returns a client to the given logical DB, or skips when Redis is
 // unreachable. It registers Close on cleanup but never flushes the DB.

--- a/internal/index/encoding_test.go
+++ b/internal/index/encoding_test.go
@@ -2,7 +2,10 @@ package index
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/hkloudou/lake/v3/internal/utils"
 )
 
 const testURI = "oss://my-bucket/4f3a/(users/0123456789abcdef.dat"
@@ -27,6 +30,10 @@ func TestDecodeMember(t *testing.T) {
 	}{
 		{mkMember(1, "/user/name", "1700000000_1", u), 1700000000.000001, "/user/name", MergeTypeReplace, TimeSeqID{1700000000, 1}, u, false},
 		{mkMember(2, "/profile", "1700000000_2", u), 1700000000.000002, "/profile", MergeTypeRFC7396, TimeSeqID{1700000000, 2}, u, false},
+		// A path longer than today's write cap must still decode: it may have
+		// been recorded before the cap existed, and reads never retro-reject.
+		{mkMember(1, "/"+strings.Repeat("a", utils.MaxFieldPathLen+64), "1700000000_3", u), 1700000000.000003,
+			"/" + strings.Repeat("a", utils.MaxFieldPathLen+64), MergeTypeReplace, TimeSeqID{1700000000, 3}, u, false},
 		// Invalid formats
 		{"not json", 0, "", 0, TimeSeqID{}, "", true},
 		{`[1,"/x"]`, 0, "", 0, TimeSeqID{}, "", true},                                            // too few elements

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -253,18 +253,18 @@ func (r *Reader) BatchList(ctx context.Context, catalogs []string) map[string]*B
 		return out
 	}
 
-	cmds := r.evalListPipelined(ctx, catalogs)
+	cmds := r.evalListPipelined(ctx, catalogs, false)
 	// Script.Run's NOSCRIPT fallback cannot fire inside a pipeline (command
 	// errors surface only at Exec), so the cold-cache case is handled here:
-	// load the script once and re-run the whole pipeline. Rare — the first
-	// BatchList of a process against a server that has never seen the script,
-	// or a restarted / SCRIPT-FLUSHed one. The load is best-effort: if Redis
-	// is down, the retry surfaces the real connection error, which is more
-	// truthful than either the load error or a misleading NOSCRIPT.
+	// re-run the whole pipeline with full-body EVAL, which executes AND
+	// re-caches the script in one step — the same strategy as Script.Run,
+	// and it needs no SCRIPT LOAD permission (ACL/proxy setups may deny that
+	// while allowing EVAL). Rare — the first BatchList of a process against
+	// a server that has never seen the script, or a restarted /
+	// SCRIPT-FLUSHed one; listScript is read-only, so re-running is safe.
 	for _, cmd := range cmds {
 		if redis.HasErrorPrefix(cmd.Err(), "NOSCRIPT") {
-			_ = luaList.Load(ctx, r.rdb).Err()
-			cmds = r.evalListPipelined(ctx, catalogs)
+			cmds = r.evalListPipelined(ctx, catalogs, true)
 			break
 		}
 	}
@@ -281,13 +281,20 @@ func (r *Reader) BatchList(ctx context.Context, catalogs []string) map[string]*B
 	return out
 }
 
-// evalListPipelined queues one EVALSHA of listScript per catalog on a single
-// pipeline and executes it; only the 40-byte SHA travels per catalog.
-func (r *Reader) evalListPipelined(ctx context.Context, catalogs []string) map[string]*redis.Cmd {
+// evalListPipelined queues one listScript call per catalog on a single
+// pipeline and executes it. With fullBody false it uses EVALSHA (only the
+// 40-byte SHA travels per catalog); with fullBody true it uses EVAL — the
+// cold-cache retry path, which also re-caches the script server-side.
+func (r *Reader) evalListPipelined(ctx context.Context, catalogs []string, fullBody bool) map[string]*redis.Cmd {
 	pipe := r.rdb.Pipeline()
 	cmds := make(map[string]*redis.Cmd, len(catalogs))
 	for _, c := range catalogs {
-		cmds[c] = luaList.EvalSha(ctx, pipe, []string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(c)}, c)
+		keys := []string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(c)}
+		if fullBody {
+			cmds[c] = luaList.Eval(ctx, pipe, keys, c)
+		} else {
+			cmds[c] = luaList.EvalSha(ctx, pipe, keys, c)
+		}
 	}
 	pipe.Exec(ctx)
 	return cmds

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -254,16 +254,14 @@ func (r *Reader) BatchList(ctx context.Context, catalogs []string) map[string]*B
 	}
 
 	cmds := r.evalListPipelined(ctx, catalogs, false)
-	// Script.Run's NOSCRIPT fallback cannot fire inside a pipeline (command
-	// errors surface only at Exec), so the cold-cache case is handled here:
+	// RunScript's fallback cannot fire inside a pipeline (command errors
+	// surface only at Exec), so it is mirrored here with the same predicate:
 	// re-run the whole pipeline with full-body EVAL, which executes AND
-	// re-caches the script in one step — the same strategy as Script.Run,
-	// and it needs no SCRIPT LOAD permission (ACL/proxy setups may deny that
-	// while allowing EVAL). Rare — the first BatchList of a process against
-	// a server that has never seen the script, or a restarted /
-	// SCRIPT-FLUSHed one; listScript is read-only, so re-running is safe.
+	// re-caches the script in one step — no SCRIPT LOAD (or even EVALSHA)
+	// permission required. Rare — a cold script cache, or an ACL that denies
+	// EVALSHA; listScript is read-only, so re-running is always safe.
 	for _, cmd := range cmds {
-		if redis.HasErrorPrefix(cmd.Err(), "NOSCRIPT") {
+		if needsEvalFallback(cmd.Err()) {
 			cmds = r.evalListPipelined(ctx, catalogs, true)
 			break
 		}

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -92,10 +92,14 @@ end
 return {snap or false, rg, redis.call("ZRANGEBYSCORE", KEYS[2], min, "+inf", "WITHSCORES")}
 `
 
+// luaList dispatches listScript by SHA (EVALSHA, falling back to EVAL on a
+// cold script cache) so the ~1 KB script body is not re-sent on every List.
+var luaList = redis.NewScript(listScript)
+
 // ListCatalog atomically reads the snap pointer and the deltas past it —
 // the single read primitive behind Client.List / Client.BatchList.
 func (r *Reader) ListCatalog(ctx context.Context, catalog string) (*SnapInfo, *ReadIndexResult) {
-	res, err := r.rdb.Eval(ctx, listScript,
+	res, err := luaList.Run(ctx, r.rdb,
 		[]string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(catalog)},
 		catalog,
 	).Result()
@@ -249,15 +253,24 @@ func (r *Reader) BatchList(ctx context.Context, catalogs []string) map[string]*B
 		return out
 	}
 
-	pipe := r.rdb.Pipeline()
-	cmds := make(map[string]*redis.Cmd, len(catalogs))
-	for _, c := range catalogs {
-		out[c] = &BatchListResult{}
-		cmds[c] = pipe.Eval(ctx, listScript,
-			[]string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(c)}, c)
+	cmds := r.evalListPipelined(ctx, catalogs)
+	// Script.Run's NOSCRIPT fallback cannot fire inside a pipeline (command
+	// errors surface only at Exec), so the cold-cache case is handled here:
+	// load the script once and re-run the whole pipeline. Rare — the first
+	// BatchList of a process against a server that has never seen the script,
+	// or a restarted / SCRIPT-FLUSHed one. The load is best-effort: if Redis
+	// is down, the retry surfaces the real connection error, which is more
+	// truthful than either the load error or a misleading NOSCRIPT.
+	for _, cmd := range cmds {
+		if redis.HasErrorPrefix(cmd.Err(), "NOSCRIPT") {
+			_ = luaList.Load(ctx, r.rdb).Err()
+			cmds = r.evalListPipelined(ctx, catalogs)
+			break
+		}
 	}
-	pipe.Exec(ctx)
+
 	for c, cmd := range cmds {
+		out[c] = &BatchListResult{}
 		res, err := cmd.Result()
 		if err != nil {
 			out[c].ReadResult = &ReadIndexResult{Catalog: c, Err: fmt.Errorf("list eval: %w", err)}
@@ -266,6 +279,18 @@ func (r *Reader) BatchList(ctx context.Context, catalogs []string) map[string]*B
 		out[c].Snap, out[c].ReadResult = r.parseListResult(c, res)
 	}
 	return out
+}
+
+// evalListPipelined queues one EVALSHA of listScript per catalog on a single
+// pipeline and executes it; only the 40-byte SHA travels per catalog.
+func (r *Reader) evalListPipelined(ctx context.Context, catalogs []string) map[string]*redis.Cmd {
+	pipe := r.rdb.Pipeline()
+	cmds := make(map[string]*redis.Cmd, len(catalogs))
+	for _, c := range catalogs {
+		cmds[c] = luaList.EvalSha(ctx, pipe, []string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(c)}, c)
+	}
+	pipe.Exec(ctx)
+	return cmds
 }
 
 // processZMembers parses zset entries into deltas. V3 has no pending
@@ -310,13 +335,9 @@ func (r *Reader) NowUnix() int64 {
 }
 
 func (r *Reader) serverUnix(ctx context.Context) (int64, error) {
-	res, err := r.rdb.Eval(ctx, `return tonumber(redis.call("TIME")[1])`, nil).Result()
+	t, err := r.rdb.Time(ctx).Result()
 	if err != nil {
 		return 0, err
 	}
-	ts, ok := res.(int64)
-	if !ok {
-		return 0, fmt.Errorf("redis TIME returned %T, want int64", res)
-	}
-	return ts, nil
+	return t.Unix(), nil
 }

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -99,7 +99,7 @@ var luaList = redis.NewScript(listScript)
 // ListCatalog atomically reads the snap pointer and the deltas past it —
 // the single read primitive behind Client.List / Client.BatchList.
 func (r *Reader) ListCatalog(ctx context.Context, catalog string) (*SnapInfo, *ReadIndexResult) {
-	res, err := luaList.Run(ctx, r.rdb,
+	res, err := RunScript(ctx, r.rdb, luaList,
 		[]string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(catalog)},
 		catalog,
 	).Result()

--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -94,7 +94,7 @@ return {snap or false, rg, redis.call("ZRANGEBYSCORE", KEYS[2], min, "+inf", "WI
 
 // luaList dispatches listScript by SHA (EVALSHA, falling back to EVAL on a
 // cold script cache) so the ~1 KB script body is not re-sent on every List.
-var luaList = redis.NewScript(listScript)
+var luaList = NewScript(listScript)
 
 // ListCatalog atomically reads the snap pointer and the deltas past it —
 // the single read primitive behind Client.List / Client.BatchList.
@@ -282,16 +282,21 @@ func (r *Reader) BatchList(ctx context.Context, catalogs []string) map[string]*B
 // evalListPipelined queues one listScript call per catalog on a single
 // pipeline and executes it. With fullBody false it uses EVALSHA (only the
 // 40-byte SHA travels per catalog); with fullBody true it uses EVAL — the
-// cold-cache retry path, which also re-caches the script server-side.
+// cold-cache retry path, which also re-caches the script server-side. When
+// SHA-1 is unavailable (fips140=only) it is EVAL-only, mirroring RunScript.
 func (r *Reader) evalListPipelined(ctx context.Context, catalogs []string, fullBody bool) map[string]*redis.Cmd {
+	compiled := luaList.compiled()
+	if compiled == nil {
+		fullBody = true
+	}
 	pipe := r.rdb.Pipeline()
 	cmds := make(map[string]*redis.Cmd, len(catalogs))
 	for _, c := range catalogs {
 		keys := []string{r.MakeSnapsHashKey(), r.MakeDeltaZsetKey(c)}
 		if fullBody {
-			cmds[c] = luaList.Eval(ctx, pipe, keys, c)
+			cmds[c] = pipe.Eval(ctx, luaList.src, keys, c)
 		} else {
-			cmds[c] = luaList.EvalSha(ctx, pipe, keys, c)
+			cmds[c] = compiled.EvalSha(ctx, pipe, keys, c)
 		}
 	}
 	pipe.Exec(ctx)

--- a/internal/index/reader_snap_hash_test.go
+++ b/internal/index/reader_snap_hash_test.go
@@ -15,11 +15,17 @@ import (
 // and a unique key prefix, or skips when Redis is unreachable. Shared by every
 // index Redis test (snap hash, notify). It never flushes the DB: cleanup
 // deletes only this test's "<prefix>:*" keys, so any other data is untouched.
+// The address defaults to 127.0.0.1:6379; LAKE_TEST_REDIS_ADDR overrides it
+// (same variable the root package's helper honours).
 func indexTestRedis(t *testing.T) (*redis.Client, string) {
 	t.Helper()
+	addr := os.Getenv("LAKE_TEST_REDIS_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:6379"
+	}
 	// MaxRetries -1 / DialerRetries 1: fail the skip probe fast when Redis is
 	// absent instead of burning the ping context in go-redis retry loops.
-	rdb := redis.NewClient(&redis.Options{Addr: "127.0.0.1:6379", DB: 13, DialTimeout: 200 * time.Millisecond, MaxRetries: -1, DialerRetries: 1})
+	rdb := redis.NewClient(&redis.Options{Addr: addr, DB: 13, DialTimeout: 200 * time.Millisecond, MaxRetries: -1, DialerRetries: 1})
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 	if err := rdb.Ping(ctx).Err(); err != nil {

--- a/internal/index/script.go
+++ b/internal/index/script.go
@@ -6,18 +6,34 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// RunScript dispatches a script by SHA with a full-body EVAL fallback on a
-// cold script cache — Script.Run with a laxer NOSCRIPT test. go-redis v9
-// falls back only when the reply is byte-identical to real Redis's message
-// (errors.Is against ErrNoScript, a plain string error with no Is method),
-// which misses Redis-compatible servers that spell it "ERR NOSCRIPT ..." —
-// the very variant redis.HasErrorPrefix exists to absorb (KVRocks). Every
-// Lake script call — here and in the sample memo — routes through this one
-// helper (or BatchList's pipelined equivalent) so all sites stay equally lax.
+// RunScript dispatches a script by SHA with a full-body EVAL fallback —
+// Script.Run with a laxer fallback test (see needsEvalFallback). go-redis v9
+// falls back only when the reply is byte-identical to real Redis's NOSCRIPT
+// message (errors.Is against ErrNoScript, a plain string error with no Is
+// method), which misses Redis-compatible servers that spell it
+// "ERR NOSCRIPT ..." — the very variant redis.HasErrorPrefix exists to
+// absorb (KVRocks) — and EVALSHA-denying ACLs. Every Lake script call — here
+// and in the sample memo — routes through this one helper (or BatchList's
+// pipelined equivalent) so all sites stay equally lax.
 func RunScript(ctx context.Context, c redis.Scripter, s *redis.Script, keys []string, args ...any) *redis.Cmd {
 	r := s.EvalSha(ctx, c, keys, args...)
-	if redis.HasErrorPrefix(r.Err(), "NOSCRIPT") {
+	if needsEvalFallback(r.Err()) {
 		return s.Eval(ctx, c, keys, args...)
 	}
 	return r
+}
+
+// needsEvalFallback reports whether an EVALSHA reply means the full-body
+// EVAL path should be tried instead:
+//
+//   - NOSCRIPT: cold script cache (server restart / SCRIPT FLUSH / first use).
+//   - NOPERM: ACLs are per command, so a user provisioned for the pre-EVALSHA
+//     code path may allow EVAL but not EVALSHA — EVAL must keep working there.
+//
+// Both are pre-execution rejections — the script did not run — so the retry
+// can never double-apply a write script. A NOPERM that denies EVAL too (or
+// is about the keys) just surfaces from the retry: one extra round-trip on
+// an already-failing call, and the more truthful error.
+func needsEvalFallback(err error) bool {
+	return redis.HasErrorPrefix(err, "NOSCRIPT") || redis.HasErrorPrefix(err, "NOPERM")
 }

--- a/internal/index/script.go
+++ b/internal/index/script.go
@@ -1,0 +1,23 @@
+package index
+
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RunScript dispatches a script by SHA with a full-body EVAL fallback on a
+// cold script cache — Script.Run with a laxer NOSCRIPT test. go-redis v9
+// falls back only when the reply is byte-identical to real Redis's message
+// (errors.Is against ErrNoScript, a plain string error with no Is method),
+// which misses Redis-compatible servers that spell it "ERR NOSCRIPT ..." —
+// the very variant redis.HasErrorPrefix exists to absorb (KVRocks). Every
+// Lake script call — here and in the sample memo — routes through this one
+// helper (or BatchList's pipelined equivalent) so all sites stay equally lax.
+func RunScript(ctx context.Context, c redis.Scripter, s *redis.Script, keys []string, args ...any) *redis.Cmd {
+	r := s.EvalSha(ctx, c, keys, args...)
+	if redis.HasErrorPrefix(r.Err(), "NOSCRIPT") {
+		return s.Eval(ctx, c, keys, args...)
+	}
+	return r
+}

--- a/internal/index/script.go
+++ b/internal/index/script.go
@@ -2,9 +2,36 @@ package index
 
 import (
 	"context"
+	"strings"
+	"sync"
 
 	"github.com/redis/go-redis/v9"
 )
+
+// Script is a lazily-compiled Redis Lua script. redis.NewScript computes a
+// SHA-1 digest eagerly — under Go's fips140=only mode that PANICS, and a
+// package-level value would take the whole importing process down before
+// main() runs. Compilation is therefore deferred to first use and guarded:
+// when SHA-1 is unavailable the script permanently degrades to full-body
+// EVAL dispatch — exactly the pre-EVALSHA behavior, just less efficient.
+type Script struct {
+	src  string
+	once sync.Once
+	s    *redis.Script // nil when SHA-1 is unavailable (fips140=only)
+}
+
+// NewScript wraps src for lazy compilation; safe as a package-level value in
+// any runtime. (Do not reach for redis.NewScript directly in Lake — that
+// reintroduces the import-time SHA-1.)
+func NewScript(src string) *Script { return &Script{src: src} }
+
+func (p *Script) compiled() *redis.Script {
+	p.once.Do(func() {
+		defer func() { _ = recover() }() // fips140=only: sha1 panics → stay nil
+		p.s = redis.NewScript(p.src)
+	})
+	return p.s
+}
 
 // RunScript dispatches a script by SHA with a full-body EVAL fallback —
 // Script.Run with a laxer fallback test (see needsEvalFallback). go-redis v9
@@ -15,10 +42,15 @@ import (
 // absorb (KVRocks) — and EVALSHA-denying ACLs. Every Lake script call — here
 // and in the sample memo — routes through this one helper (or BatchList's
 // pipelined equivalent) so all sites stay equally lax.
-func RunScript(ctx context.Context, c redis.Scripter, s *redis.Script, keys []string, args ...any) *redis.Cmd {
-	r := s.EvalSha(ctx, c, keys, args...)
+func RunScript(ctx context.Context, c redis.Scripter, s *Script, keys []string, args ...any) *redis.Cmd {
+	compiled := s.compiled()
+	if compiled == nil {
+		// SHA-1 unavailable (fips140=only): plain EVAL, the pre-EVALSHA path.
+		return c.Eval(ctx, s.src, keys, args...)
+	}
+	r := compiled.EvalSha(ctx, c, keys, args...)
 	if needsEvalFallback(r.Err()) {
-		return s.Eval(ctx, c, keys, args...)
+		return compiled.Eval(ctx, c, keys, args...)
 	}
 	return r
 }
@@ -27,13 +59,19 @@ func RunScript(ctx context.Context, c redis.Scripter, s *redis.Script, keys []st
 // EVAL path should be tried instead:
 //
 //   - NOSCRIPT: cold script cache (server restart / SCRIPT FLUSH / first use).
-//   - NOPERM: ACLs are per command, so a user provisioned for the pre-EVALSHA
-//     code path may allow EVAL but not EVALSHA — EVAL must keep working there.
+//   - NOPERM naming the 'evalsha' command: ACLs are per command, so a user
+//     provisioned for the pre-EVALSHA code path may allow EVAL but not
+//     EVALSHA — EVAL must keep working there.
 //
-// Both are pre-execution rejections — the script did not run — so the retry
-// can never double-apply a write script. A NOPERM that denies EVAL too (or
-// is about the keys) just surfaces from the retry: one extra round-trip on
-// an already-failing call, and the more truthful error.
+// Both are raised BEFORE the script body runs, so the retry can never
+// double-apply a write script. Any other NOPERM must NOT retry: a command
+// denied INSIDE the script (per-command / per-key ACL) surfaces after the
+// script's earlier writes already took effect — Redis scripts do not roll
+// back — and rerunning the body would apply them twice. Those messages name
+// the inner command or the keys, never 'evalsha'.
 func needsEvalFallback(err error) bool {
-	return redis.HasErrorPrefix(err, "NOSCRIPT") || redis.HasErrorPrefix(err, "NOPERM")
+	if redis.HasErrorPrefix(err, "NOSCRIPT") {
+		return true
+	}
+	return redis.HasErrorPrefix(err, "NOPERM") && strings.Contains(err.Error(), "'evalsha'")
 }

--- a/internal/index/script_dispatch_test.go
+++ b/internal/index/script_dispatch_test.go
@@ -1,0 +1,60 @@
+package index
+
+import (
+	"context"
+	"testing"
+)
+
+// TestScriptDispatchSurvivesScriptFlush pins the EVALSHA dispatch against a
+// cold server script cache — the state after a Redis restart or a SCRIPT
+// FLUSH. Single calls recover via Script.Run's built-in EVAL fallback;
+// BatchList cannot (a pipelined command's error surfaces only at Exec), so it
+// carries its own load-and-retry, and this test exercises both paths.
+// SCRIPT FLUSH clears only the server's script cache, never data — any
+// EVALSHA client must tolerate it, so flushing on a shared dev Redis is safe.
+func TestScriptDispatchSurvivesScriptFlush(t *testing.T) {
+	rdb, prefix := indexTestRedis(t)
+	w := NewWriter(rdb)
+	r := NewReader(rdb)
+	w.SetPrefix(prefix)
+	r.SetPrefix(prefix)
+	ctx := context.Background()
+
+	if err := rdb.ScriptFlush(ctx).Err(); err != nil {
+		t.Fatalf("SCRIPT FLUSH: %v", err)
+	}
+	tsSeq, _, err := w.Notify(ctx, "users", "/profile", MergeTypeReplace, "oss://b/x.dat")
+	if err != nil {
+		t.Fatalf("Notify on cold script cache: %v", err)
+	}
+
+	if err := rdb.ScriptFlush(ctx).Err(); err != nil {
+		t.Fatalf("SCRIPT FLUSH: %v", err)
+	}
+	snap, rr := r.ListCatalog(ctx, "users")
+	if rr.Err != nil {
+		t.Fatalf("ListCatalog on cold script cache: %v", rr.Err)
+	}
+	if snap != nil || len(rr.Deltas) != 1 || rr.Deltas[0].TsSeq != tsSeq {
+		t.Fatalf("ListCatalog: got snap=%v deltas=%+v, want the one notified delta", snap, rr.Deltas)
+	}
+
+	if err := rdb.ScriptFlush(ctx).Err(); err != nil {
+		t.Fatalf("SCRIPT FLUSH: %v", err)
+	}
+	out := r.BatchList(ctx, []string{"users", "empty-cat"})
+	for cat, br := range out {
+		if br.ReadResult == nil {
+			t.Fatalf("BatchList[%s]: nil ReadResult", cat)
+		}
+		if br.ReadResult.Err != nil {
+			t.Fatalf("BatchList[%s] on cold script cache: %v", cat, br.ReadResult.Err)
+		}
+	}
+	if got := len(out["users"].ReadResult.Deltas); got != 1 {
+		t.Fatalf("BatchList[users]: got %d deltas, want 1", got)
+	}
+	if got := len(out["empty-cat"].ReadResult.Deltas); got != 0 {
+		t.Fatalf("BatchList[empty-cat]: got %d deltas, want 0", got)
+	}
+}

--- a/internal/index/script_dispatch_test.go
+++ b/internal/index/script_dispatch_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"os"
 	"testing"
 )
 
@@ -10,9 +11,17 @@ import (
 // FLUSH. Single calls recover via Script.Run's built-in EVAL fallback;
 // BatchList cannot (a pipelined command's error surfaces only at Exec), so it
 // carries its own load-and-retry, and this test exercises both paths.
-// SCRIPT FLUSH clears only the server's script cache, never data — any
-// EVALSHA client must tolerate it, so flushing on a shared dev Redis is safe.
+//
+// Opt-in (LAKE_TEST_SCRIPT_FLUSH=1, set by CI against its dedicated Redis):
+// SCRIPT FLUSH never touches data, but it clears the SERVER-WIDE script cache
+// — all logical DBs, all clients — and an unrelated client that pipelines
+// EVALSHA without a reload path would see hard NOSCRIPT errors. That would
+// break the "safe to point at a Redis that holds other data" promise the
+// rest of the suite keeps, so a shared Redis skips this test by default.
 func TestScriptDispatchSurvivesScriptFlush(t *testing.T) {
+	if os.Getenv("LAKE_TEST_SCRIPT_FLUSH") != "1" {
+		t.Skip("set LAKE_TEST_SCRIPT_FLUSH=1 to run (issues a server-wide SCRIPT FLUSH; only safe on a dedicated Redis)")
+	}
 	rdb, prefix := indexTestRedis(t)
 	w := NewWriter(rdb)
 	r := NewReader(rdb)

--- a/internal/index/script_test.go
+++ b/internal/index/script_test.go
@@ -54,15 +54,17 @@ func (f *fakeScripter) ScriptLoad(ctx context.Context, script string) *redis.Str
 // TestRunScriptFallsBackOnPrefixedNoScript pins why RunScript exists instead
 // of go-redis's Script.Run: v9 falls back only when the error is
 // byte-identical to real Redis's NOSCRIPT message, missing compatible servers
-// that reply "ERR NOSCRIPT ..." (the spelling HasErrorPrefix absorbs). Both
-// spellings must fall back to EVAL; any other error must not.
+// that reply "ERR NOSCRIPT ..." (the spelling HasErrorPrefix absorbs) and
+// ACL setups that allow EVAL but deny the EVALSHA command (NOPERM). All of
+// these must fall back to EVAL; any other error must not.
 func TestRunScriptFallsBackOnPrefixedNoScript(t *testing.T) {
 	ctx := context.Background()
 	s := redis.NewScript(`return 1`)
 
 	for _, spelling := range []string{
-		"NOSCRIPT No matching script. Please use EVAL.", // real Redis
-		"ERR NOSCRIPT No matching script",               // KVRocks-style prefix
+		"NOSCRIPT No matching script. Please use EVAL.",                    // real Redis
+		"ERR NOSCRIPT No matching script",                                  // KVRocks-style prefix
+		"NOPERM this user has no permissions to run the 'evalsha' command", // EVAL-only ACL
 	} {
 		f := &fakeScripter{shaErr: fakeRedisErr(spelling), evalReply: "ok"}
 		res, err := RunScript(ctx, f, s, nil).Result()

--- a/internal/index/script_test.go
+++ b/internal/index/script_test.go
@@ -55,11 +55,16 @@ func (f *fakeScripter) ScriptLoad(ctx context.Context, script string) *redis.Str
 // of go-redis's Script.Run: v9 falls back only when the error is
 // byte-identical to real Redis's NOSCRIPT message, missing compatible servers
 // that reply "ERR NOSCRIPT ..." (the spelling HasErrorPrefix absorbs) and
-// ACL setups that allow EVAL but deny the EVALSHA command (NOPERM). All of
-// these must fall back to EVAL; any other error must not.
+// ACL setups that allow EVAL but deny the EVALSHA command itself. Those must
+// fall back to EVAL; everything else must not — in particular a NOPERM from
+// a command INSIDE the script, which arrives after the script's earlier
+// writes took effect, so a rerun would double-apply them.
 func TestRunScriptFallsBackOnPrefixedNoScript(t *testing.T) {
 	ctx := context.Background()
-	s := redis.NewScript(`return 1`)
+	s := NewScript(`return 1`)
+	if s.compiled() == nil {
+		t.Skip("local SHA-1 unavailable (fips140=only): EVALSHA dispatch degrades to plain EVAL; see TestRunScriptDegradesWithoutSHA1")
+	}
 
 	for _, spelling := range []string{
 		"NOSCRIPT No matching script. Please use EVAL.",                    // real Redis
@@ -79,12 +84,39 @@ func TestRunScriptFallsBackOnPrefixedNoScript(t *testing.T) {
 		}
 	}
 
-	// A non-NOSCRIPT error must surface as-is, with no EVAL retry.
-	f := &fakeScripter{shaErr: fakeRedisErr("READONLY You can't write against a read only replica.")}
-	if _, err := RunScript(ctx, f, s, nil).Result(); err == nil {
-		t.Fatal("non-NOSCRIPT error: expected error, got nil")
+	// Errors that must surface as-is, with no EVAL retry: unrelated failures,
+	// and NOPERM raised by ACL rules INSIDE the script (inner command / keys)
+	// — the script body already ran up to the denial and must not run twice.
+	for _, spelling := range []string{
+		"READONLY You can't write against a read only replica.",
+		"NOPERM this user has no permissions to run the 'zrem' command",
+		"NOPERM this user has no permissions to access one of the keys used as arguments",
+	} {
+		f := &fakeScripter{shaErr: fakeRedisErr(spelling)}
+		if _, err := RunScript(ctx, f, s, nil).Result(); err == nil {
+			t.Fatalf("spelling %q: expected error, got nil", spelling)
+		}
+		if f.evalN != 0 {
+			t.Fatalf("spelling %q: Eval called %d times, want 0 (no retry)", spelling, f.evalN)
+		}
 	}
-	if f.evalN != 0 {
-		t.Fatalf("non-NOSCRIPT error: Eval called %d times, want 0", f.evalN)
+}
+
+// TestRunScriptDegradesWithoutSHA1 pins the fips140=only path: when local
+// SHA-1 is unavailable, compilation yields nil and every call must go
+// straight to full-body EVAL — never EVALSHA, never SCRIPT LOAD. (The nil
+// state is induced directly; the real trigger is redis.NewScript panicking
+// under GODEBUG=fips140=only, which lazy compilation contains.)
+func TestRunScriptDegradesWithoutSHA1(t *testing.T) {
+	s := NewScript(`return 1`)
+	s.once.Do(func() {}) // consume the once with s.s left nil, as a sha1 panic would
+
+	f := &fakeScripter{evalReply: "ok"}
+	res, err := RunScript(context.Background(), f, s, nil).Result()
+	if err != nil || res != "ok" {
+		t.Fatalf("got (%v, %v), want (ok, nil) via plain EVAL", res, err)
+	}
+	if f.evalShaN != 0 || f.evalN != 1 || f.loadN != 0 {
+		t.Fatalf("EvalSha=%d Eval=%d Load=%d, want 0/1/0", f.evalShaN, f.evalN, f.loadN)
 	}
 }

--- a/internal/index/script_test.go
+++ b/internal/index/script_test.go
@@ -1,0 +1,88 @@
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// fakeRedisErr satisfies go-redis's Error interface (a server-sent error), so
+// HasErrorPrefix treats it exactly like a real reply error.
+type fakeRedisErr string
+
+func (e fakeRedisErr) Error() string { return string(e) }
+func (fakeRedisErr) RedisError()     {}
+
+// fakeScripter fails every EVALSHA with a fixed error and succeeds on EVAL,
+// recording what was called — a stand-in for a cold-cache server.
+type fakeScripter struct {
+	shaErr    error
+	evalShaN  int
+	evalN     int
+	loadN     int
+	evalReply any
+}
+
+func (f *fakeScripter) EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+	f.evalShaN++
+	return redis.NewCmdResult(nil, f.shaErr)
+}
+
+func (f *fakeScripter) Eval(ctx context.Context, script string, keys []string, args ...interface{}) *redis.Cmd {
+	f.evalN++
+	return redis.NewCmdResult(f.evalReply, nil)
+}
+
+func (f *fakeScripter) EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+	return redis.NewCmdResult(nil, f.shaErr)
+}
+
+func (f *fakeScripter) EvalRO(ctx context.Context, script string, keys []string, args ...interface{}) *redis.Cmd {
+	return redis.NewCmdResult(f.evalReply, nil)
+}
+
+func (f *fakeScripter) ScriptExists(ctx context.Context, hashes ...string) *redis.BoolSliceCmd {
+	return redis.NewBoolSliceResult(nil, nil)
+}
+
+func (f *fakeScripter) ScriptLoad(ctx context.Context, script string) *redis.StringCmd {
+	f.loadN++
+	return redis.NewStringResult("", nil)
+}
+
+// TestRunScriptFallsBackOnPrefixedNoScript pins why RunScript exists instead
+// of go-redis's Script.Run: v9 falls back only when the error is
+// byte-identical to real Redis's NOSCRIPT message, missing compatible servers
+// that reply "ERR NOSCRIPT ..." (the spelling HasErrorPrefix absorbs). Both
+// spellings must fall back to EVAL; any other error must not.
+func TestRunScriptFallsBackOnPrefixedNoScript(t *testing.T) {
+	ctx := context.Background()
+	s := redis.NewScript(`return 1`)
+
+	for _, spelling := range []string{
+		"NOSCRIPT No matching script. Please use EVAL.", // real Redis
+		"ERR NOSCRIPT No matching script",               // KVRocks-style prefix
+	} {
+		f := &fakeScripter{shaErr: fakeRedisErr(spelling), evalReply: "ok"}
+		res, err := RunScript(ctx, f, s, nil).Result()
+		if err != nil || res != "ok" {
+			t.Fatalf("spelling %q: got (%v, %v), want fallback result (ok, nil)", spelling, res, err)
+		}
+		if f.evalShaN != 1 || f.evalN != 1 {
+			t.Fatalf("spelling %q: EvalSha=%d Eval=%d, want 1/1", spelling, f.evalShaN, f.evalN)
+		}
+		if f.loadN != 0 {
+			t.Fatalf("spelling %q: SCRIPT LOAD called %d times, want 0 (may be ACL-denied)", spelling, f.loadN)
+		}
+	}
+
+	// A non-NOSCRIPT error must surface as-is, with no EVAL retry.
+	f := &fakeScripter{shaErr: fakeRedisErr("READONLY You can't write against a read only replica.")}
+	if _, err := RunScript(ctx, f, s, nil).Result(); err == nil {
+		t.Fatal("non-NOSCRIPT error: expected error, got nil")
+	}
+	if f.evalN != 0 {
+		t.Fatalf("non-NOSCRIPT error: Eval called %d times, want 0", f.evalN)
+	}
+}

--- a/internal/index/writer_atomic.go
+++ b/internal/index/writer_atomic.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/hkloudou/lake/v3/internal/encode"
-	"github.com/redis/go-redis/v9"
 )
 
 // notifyScript atomically allocates a TimeSeqID and adds the committed delta
@@ -46,7 +45,7 @@ return {tonumber(ts), seqid, member}
 
 // luaNotify dispatches notifyScript by SHA — the hottest write-path script,
 // so its body travels once per server, not once per write.
-var luaNotify = redis.NewScript(notifyScript)
+var luaNotify = NewScript(notifyScript)
 
 // Notify allocates a TimeSeqID for an already-uploaded delta and commits it to
 // the Redis index. uri is the storage locator (provider://bucket/path) the

--- a/internal/index/writer_atomic.go
+++ b/internal/index/writer_atomic.go
@@ -56,7 +56,7 @@ func (w *Writer) Notify(ctx context.Context, catalog, fieldPath string, mergeTyp
 	if w.prefix == "" {
 		return TimeSeqID{}, "", fmt.Errorf("writer prefix not set; call SetPrefix")
 	}
-	res, err := luaNotify.Run(ctx, w.rdb,
+	res, err := RunScript(ctx, w.rdb, luaNotify,
 		[]string{encode.EncodeRedisCatalogName(catalog), w.MakeDeltaZsetKey(catalog)},
 		fieldPath, int(mergeType), w.prefix, uri,
 	).Result()

--- a/internal/index/writer_atomic.go
+++ b/internal/index/writer_atomic.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hkloudou/lake/v3/internal/encode"
+	"github.com/redis/go-redis/v9"
 )
 
 // notifyScript atomically allocates a TimeSeqID and adds the committed delta
@@ -43,6 +44,10 @@ redis.call("ZADD", zaddKey, score, member)
 return {tonumber(ts), seqid, member}
 `
 
+// luaNotify dispatches notifyScript by SHA — the hottest write-path script,
+// so its body travels once per server, not once per write.
+var luaNotify = redis.NewScript(notifyScript)
+
 // Notify allocates a TimeSeqID for an already-uploaded delta and commits it to
 // the Redis index. uri is the storage locator (provider://bucket/path) the
 // client uploaded to; it is embedded in the member so reads resolve the body
@@ -51,7 +56,7 @@ func (w *Writer) Notify(ctx context.Context, catalog, fieldPath string, mergeTyp
 	if w.prefix == "" {
 		return TimeSeqID{}, "", fmt.Errorf("writer prefix not set; call SetPrefix")
 	}
-	res, err := w.rdb.Eval(ctx, notifyScript,
+	res, err := luaNotify.Run(ctx, w.rdb,
 		[]string{encode.EncodeRedisCatalogName(catalog), w.MakeDeltaZsetKey(catalog)},
 		fieldPath, int(mergeType), w.prefix, uri,
 	).Result()

--- a/internal/index/writer_delta.go
+++ b/internal/index/writer_delta.go
@@ -49,7 +49,7 @@ var luaRemoveDelta = redis.NewScript(removeDeltaScript)
 // the catalog's removal generation. The body object in storage is untouched.
 // Returns whether an entry was removed.
 func (w *Writer) RemoveDelta(ctx context.Context, catalog string, tsSeq TimeSeqID) (bool, error) {
-	res, err := luaRemoveDelta.Run(ctx, w.rdb,
+	res, err := RunScript(ctx, w.rdb, luaRemoveDelta,
 		[]string{w.MakeDeltaZsetKey(catalog), w.MakeSnapsHashKey()},
 		tsSeq.Score(), tsSeq.String(), catalog,
 	).Result()

--- a/internal/index/writer_delta.go
+++ b/internal/index/writer_delta.go
@@ -3,6 +3,8 @@ package index
 import (
 	"context"
 	"fmt"
+
+	"github.com/redis/go-redis/v9"
 )
 
 // removeDeltaScript removes exactly one delta entry, located by its score and
@@ -39,11 +41,15 @@ end
 return 0
 `
 
+// luaRemoveDelta dispatches removeDeltaScript by SHA (EVALSHA with EVAL
+// fallback on a cold script cache).
+var luaRemoveDelta = redis.NewScript(removeDeltaScript)
+
 // RemoveDelta deletes the delta index entry with the given tsSeq and bumps
 // the catalog's removal generation. The body object in storage is untouched.
 // Returns whether an entry was removed.
 func (w *Writer) RemoveDelta(ctx context.Context, catalog string, tsSeq TimeSeqID) (bool, error) {
-	res, err := w.rdb.Eval(ctx, removeDeltaScript,
+	res, err := luaRemoveDelta.Run(ctx, w.rdb,
 		[]string{w.MakeDeltaZsetKey(catalog), w.MakeSnapsHashKey()},
 		tsSeq.Score(), tsSeq.String(), catalog,
 	).Result()

--- a/internal/index/writer_delta.go
+++ b/internal/index/writer_delta.go
@@ -3,8 +3,6 @@ package index
 import (
 	"context"
 	"fmt"
-
-	"github.com/redis/go-redis/v9"
 )
 
 // removeDeltaScript removes exactly one delta entry, located by its score and
@@ -43,7 +41,7 @@ return 0
 
 // luaRemoveDelta dispatches removeDeltaScript by SHA (EVALSHA with EVAL
 // fallback on a cold script cache).
-var luaRemoveDelta = redis.NewScript(removeDeltaScript)
+var luaRemoveDelta = NewScript(removeDeltaScript)
 
 // RemoveDelta deletes the delta index entry with the given tsSeq and bumps
 // the catalog's removal generation. The body object in storage is untouched.

--- a/internal/index/writer_snap.go
+++ b/internal/index/writer_snap.go
@@ -54,8 +54,8 @@ return 1
 // luaAddSnap / luaCompactDeltas dispatch their scripts by SHA (EVALSHA with
 // EVAL fallback), so the shared snapScoreLua prelude is not re-sent per call.
 var (
-	luaAddSnap       = redis.NewScript(addSnapScript)
-	luaCompactDeltas = redis.NewScript(compactDeltasScript)
+	luaAddSnap       = NewScript(addSnapScript)
+	luaCompactDeltas = NewScript(compactDeltasScript)
 )
 
 // AddSnap upserts the catalog's snap entry in "<prefix>:s" as [tsSeq, uri],

--- a/internal/index/writer_snap.go
+++ b/internal/index/writer_snap.go
@@ -71,7 +71,7 @@ func (w *Writer) AddSnap(ctx context.Context, catalog string, stopTsSeq TimeSeqI
 	if removeGen == "" {
 		removeGen = "0"
 	}
-	return luaAddSnap.Run(ctx, w.rdb,
+	return RunScript(ctx, w.rdb, luaAddSnap,
 		[]string{w.MakeSnapsHashKey()},
 		catalog, val, stopTsSeq.Score(), removeGen,
 	).Err()
@@ -99,7 +99,7 @@ return redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", string.format("%.6f", sco
 // current snap stop, atomically with reading the snap pointer. Only index
 // entries are removed — delta objects in storage are untouched.
 func (w *Writer) CompactDeltas(ctx context.Context, catalog string) (int64, error) {
-	res, err := luaCompactDeltas.Run(ctx, w.rdb,
+	res, err := RunScript(ctx, w.rdb, luaCompactDeltas,
 		[]string{w.MakeSnapsHashKey(), w.MakeDeltaZsetKey(catalog)},
 		catalog,
 	).Result()

--- a/internal/index/writer_snap.go
+++ b/internal/index/writer_snap.go
@@ -51,6 +51,13 @@ redis.call("HSET", KEYS[1], ARGV[1], ARGV[2])
 return 1
 `
 
+// luaAddSnap / luaCompactDeltas dispatch their scripts by SHA (EVALSHA with
+// EVAL fallback), so the shared snapScoreLua prelude is not re-sent per call.
+var (
+	luaAddSnap       = redis.NewScript(addSnapScript)
+	luaCompactDeltas = redis.NewScript(compactDeltasScript)
+)
+
 // AddSnap upserts the catalog's snap entry in "<prefix>:s" as [tsSeq, uri],
 // but only monotonically, and only when removeGen still matches the
 // catalog's removal generation (see addSnapScript). Refusals are silent
@@ -64,7 +71,7 @@ func (w *Writer) AddSnap(ctx context.Context, catalog string, stopTsSeq TimeSeqI
 	if removeGen == "" {
 		removeGen = "0"
 	}
-	return w.rdb.Eval(ctx, addSnapScript,
+	return luaAddSnap.Run(ctx, w.rdb,
 		[]string{w.MakeSnapsHashKey()},
 		catalog, val, stopTsSeq.Score(), removeGen,
 	).Err()
@@ -92,7 +99,7 @@ return redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", string.format("%.6f", sco
 // current snap stop, atomically with reading the snap pointer. Only index
 // entries are removed — delta objects in storage are untouched.
 func (w *Writer) CompactDeltas(ctx context.Context, catalog string) (int64, error) {
-	res, err := w.rdb.Eval(ctx, compactDeltasScript,
+	res, err := luaCompactDeltas.Run(ctx, w.rdb,
 		[]string{w.MakeSnapsHashKey(), w.MakeDeltaZsetKey(catalog)},
 		catalog,
 	).Result()

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -29,9 +29,13 @@ const (
 	// the merge engine on every read.
 	MaxFieldPathLen = 512
 	// MaxStoragePartLen bounds provider / bucket names embedded in object
-	// URIs. Real object stores cap bucket names lower still (OSS / S3: 63
-	// chars), so a longer value can only be a mistake.
-	MaxStoragePartLen = 63
+	// URIs. This is Lake's own backend-agnostic sanity bound — both parts are
+	// recorded in every delta's URI, and a bucket maps to one path component
+	// on the file backend (255-byte limit) — NOT a cloud rule: real object
+	// stores impose tighter limits of their own (OSS / S3 buckets: 63 chars)
+	// and surface them from the backend itself, while file / mem / custom
+	// resolvers may use longer logical names up to this bound.
+	MaxStoragePartLen = 128
 )
 
 // fieldPathRegex: JSON field path used in delta members.

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -5,6 +5,30 @@ import (
 	"regexp"
 )
 
+// Length caps, in bytes, checked before the charset regexes (oversize input
+// is rejected without paying a regex scan, and without echoing itself into
+// the error). Unbounded names would pass validation here and then fail far
+// away with a confusing storage- or Redis-level error — or quietly bloat the
+// index.
+const (
+	// MaxCatalogLen bounds catalog names (and sample indicators, which share
+	// the rules). The binding constraint is the object path: a mixed-case /
+	// non-ASCII catalog is base32-encoded into ONE path component
+	// (objkey.encode), and the file backend maps components to directory
+	// names capped at 255 bytes on Linux — base32(128) = 208, safely under.
+	// Every other consumer (Redis keys, OSS/S3 keys ≤ 1023 bytes) has more
+	// headroom than that.
+	MaxCatalogLen = 128
+	// MaxFieldPathLen bounds the JSON field path. It is recorded verbatim in
+	// every delta member (Redis memory, paid per write) and replayed through
+	// the merge engine on every read.
+	MaxFieldPathLen = 512
+	// MaxStoragePartLen bounds provider / bucket names embedded in object
+	// URIs. Real object stores cap bucket names lower still (OSS / S3: 63
+	// chars), so a longer value can only be a mistake.
+	MaxStoragePartLen = 63
+)
+
 // fieldPathRegex: JSON field path used in delta members.
 //
 //   - starts with "/", does not end with "/"
@@ -13,6 +37,9 @@ import (
 var fieldPathRegex = regexp.MustCompile(`^/([a-zA-Z_$][a-zA-Z0-9_$.]*(/[a-zA-Z_$][a-zA-Z0-9_$.]*)*)?$`)
 
 func ValidateFieldPath(path string) error {
+	if len(path) > MaxFieldPathLen {
+		return fmt.Errorf("invalid field path: %d bytes exceeds the %d-byte limit", len(path), MaxFieldPathLen)
+	}
 	if !fieldPathRegex.MatchString(path) {
 		return fmt.Errorf("invalid field path %q: start with /, no trailing /, segments must follow JS variable naming", path)
 	}
@@ -26,6 +53,9 @@ func ValidateFieldPath(path string) error {
 var catalogRegex = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.\-]*(/[a-zA-Z0-9_][a-zA-Z0-9_.\-]*)*$`)
 
 func ValidateCatalog(catalog string) error {
+	if len(catalog) > MaxCatalogLen {
+		return fmt.Errorf("invalid catalog: %d bytes exceeds the %d-byte limit", len(catalog), MaxCatalogLen)
+	}
 	if !catalogRegex.MatchString(catalog) {
 		return fmt.Errorf(`invalid catalog %q: each segment ASCII [a-zA-Z0-9_][a-zA-Z0-9_.\-]*; segments joined by single "/"; no leading/trailing/doubled "/"; ":" "|" "(" ")" forbidden`, catalog)
 	}
@@ -52,6 +82,9 @@ func ValidateStorageBucket(bucket string) error {
 // validateStoragePart is the single definition of the URI-part format; the
 // two exported wrappers exist only to name the offending part in the error.
 func validateStoragePart(kind, s string) error {
+	if len(s) > MaxStoragePartLen {
+		return fmt.Errorf("invalid storage %s: %d bytes exceeds the %d-byte limit", kind, len(s), MaxStoragePartLen)
+	}
 	if !storagePartRegex.MatchString(s) {
 		return fmt.Errorf(`invalid storage %s %q: ASCII [a-zA-Z0-9][a-zA-Z0-9._\-]* required ("/" ":" "|" forbidden)`, kind, s)
 	}

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -5,11 +5,16 @@ import (
 	"regexp"
 )
 
-// Length caps, in bytes, checked before the charset regexes (oversize input
-// is rejected without paying a regex scan, and without echoing itself into
-// the error). Unbounded names would pass validation here and then fail far
-// away with a confusing storage- or Redis-level error — or quietly bloat the
-// index.
+// Length caps, in bytes, enforced ONLY where a name is being created
+// (ValidateNewCatalog / ValidateNewFieldPath — i.e. WriteBegin, WriteNotify,
+// NewSampler): unbounded new names would pass the charset checks and then
+// fail far away with a confusing storage- or Redis-level error — or quietly
+// bloat the index. Read and ops paths (List, RemoveDelta, Compact, member
+// decoding) deliberately do NOT apply them: data persisted under a longer
+// name when the cap was laxer must stay readable and removable — tightening
+// a cap must never strand existing data. The cap check runs before the
+// charset regex (oversize input is rejected without paying a regex scan,
+// and without echoing itself into the error).
 const (
 	// MaxCatalogLen bounds catalog names (and sample indicators, which share
 	// the rules). The binding constraint is the object path: a mixed-case /
@@ -36,14 +41,22 @@ const (
 //   - "|" forbidden — it is the delta-member delimiter
 var fieldPathRegex = regexp.MustCompile(`^/([a-zA-Z_$][a-zA-Z0-9_$.]*(/[a-zA-Z_$][a-zA-Z0-9_$.]*)*)?$`)
 
+// ValidateFieldPath checks the charset/shape rules only — the read-side
+// check, applied to paths already persisted in delta members.
 func ValidateFieldPath(path string) error {
-	if len(path) > MaxFieldPathLen {
-		return fmt.Errorf("invalid field path: %d bytes exceeds the %d-byte limit", len(path), MaxFieldPathLen)
-	}
 	if !fieldPathRegex.MatchString(path) {
 		return fmt.Errorf("invalid field path %q: start with /, no trailing /, segments must follow JS variable naming", path)
 	}
 	return nil
+}
+
+// ValidateNewFieldPath additionally enforces MaxFieldPathLen — the write-side
+// check for paths about to be recorded (WriteBegin / WriteNotify).
+func ValidateNewFieldPath(path string) error {
+	if len(path) > MaxFieldPathLen {
+		return fmt.Errorf("invalid field path: %d bytes exceeds the %d-byte limit", len(path), MaxFieldPathLen)
+	}
+	return ValidateFieldPath(path)
 }
 
 // catalogRegex: catalog name. Forbids ":" / "|" / "(" / ")" (Redis &
@@ -52,14 +65,24 @@ func ValidateFieldPath(path string) error {
 // non-ASCII (Unicode NFC/NFD divergence breaks Redis equality).
 var catalogRegex = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.\-]*(/[a-zA-Z0-9_][a-zA-Z0-9_.\-]*)*$`)
 
+// ValidateCatalog checks the charset/shape rules only — the read/ops-side
+// check (List, BatchList, RemoveDelta, Compact, InvalidateSamples), so a
+// catalog written under a laxer cap stays reachable.
 func ValidateCatalog(catalog string) error {
-	if len(catalog) > MaxCatalogLen {
-		return fmt.Errorf("invalid catalog: %d bytes exceeds the %d-byte limit", len(catalog), MaxCatalogLen)
-	}
 	if !catalogRegex.MatchString(catalog) {
 		return fmt.Errorf(`invalid catalog %q: each segment ASCII [a-zA-Z0-9_][a-zA-Z0-9_.\-]*; segments joined by single "/"; no leading/trailing/doubled "/"; ":" "|" "(" ")" forbidden`, catalog)
 	}
 	return nil
+}
+
+// ValidateNewCatalog additionally enforces MaxCatalogLen — the write-side
+// check for names about to mint new state (WriteBegin / WriteNotify deltas,
+// NewSampler memo fields).
+func ValidateNewCatalog(catalog string) error {
+	if len(catalog) > MaxCatalogLen {
+		return fmt.Errorf("invalid catalog: %d bytes exceeds the %d-byte limit", len(catalog), MaxCatalogLen)
+	}
+	return ValidateCatalog(catalog)
 }
 
 // storagePartRegex: storage provider / bucket name, as embedded in object

--- a/internal/utils/validate_catalog_test.go
+++ b/internal/utils/validate_catalog_test.go
@@ -1,6 +1,9 @@
 package utils
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidateCatalog_Accepted(t *testing.T) {
 	cases := []string{
@@ -18,6 +21,7 @@ func TestValidateCatalog_Accepted(t *testing.T) {
 		"_users",     // underscore-led segment OK
 		"123-tenant", // digit-led segment OK
 		"v3.0.0-alpha.1",
+		strings.Repeat("a", MaxCatalogLen), // exactly at the length cap
 	}
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {
@@ -58,6 +62,7 @@ func TestValidateCatalog_Rejected(t *testing.T) {
 		{"asterisk", "tenant*users"},
 		{"question_mark", "tenant?users"},
 		{"control_char", "tenant\x00users"},
+		{"over_length_cap", strings.Repeat("a", MaxCatalogLen+1)},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -104,6 +109,8 @@ func TestValidateFieldPath(t *testing.T) {
 		{"starts with dot", "/.config", true},
 		{"segment starts with dot", "/user/.config", true},
 		{"contains chinese characters", "/用户", true},
+		{"exactly at length cap", "/" + strings.Repeat("a", MaxFieldPathLen-1), false},
+		{"over length cap", "/" + strings.Repeat("a", MaxFieldPathLen), true},
 	}
 
 	for _, tt := range tests {

--- a/internal/utils/validate_catalog_test.go
+++ b/internal/utils/validate_catalog_test.go
@@ -62,7 +62,6 @@ func TestValidateCatalog_Rejected(t *testing.T) {
 		{"asterisk", "tenant*users"},
 		{"question_mark", "tenant?users"},
 		{"control_char", "tenant\x00users"},
-		{"over_length_cap", strings.Repeat("a", MaxCatalogLen+1)},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -109,8 +108,6 @@ func TestValidateFieldPath(t *testing.T) {
 		{"starts with dot", "/.config", true},
 		{"segment starts with dot", "/user/.config", true},
 		{"contains chinese characters", "/用户", true},
-		{"exactly at length cap", "/" + strings.Repeat("a", MaxFieldPathLen-1), false},
-		{"over length cap", "/" + strings.Repeat("a", MaxFieldPathLen), true},
 	}
 
 	for _, tt := range tests {
@@ -120,5 +117,42 @@ func TestValidateFieldPath(t *testing.T) {
 				t.Errorf("ValidateFieldPath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestLengthCapsBindOnlyOnCreate pins the write/read validation split: the
+// New* variants reject names past the cap, while the plain variants accept
+// them — data persisted under a longer name when the cap was laxer must stay
+// listable, readable, and removable after an upgrade.
+func TestLengthCapsBindOnlyOnCreate(t *testing.T) {
+	longCatalog := strings.Repeat("a", MaxCatalogLen+1)
+	longPath := "/" + strings.Repeat("a", MaxFieldPathLen)
+
+	if err := ValidateNewCatalog(strings.Repeat("a", MaxCatalogLen)); err != nil {
+		t.Errorf("ValidateNewCatalog at cap: unexpected error: %v", err)
+	}
+	if err := ValidateNewCatalog(longCatalog); err == nil {
+		t.Error("ValidateNewCatalog over cap: expected error, got nil")
+	}
+	if err := ValidateCatalog(longCatalog); err != nil {
+		t.Errorf("ValidateCatalog must accept legacy over-cap names, got: %v", err)
+	}
+
+	if err := ValidateNewFieldPath("/" + strings.Repeat("a", MaxFieldPathLen-1)); err != nil {
+		t.Errorf("ValidateNewFieldPath at cap: unexpected error: %v", err)
+	}
+	if err := ValidateNewFieldPath(longPath); err == nil {
+		t.Error("ValidateNewFieldPath over cap: expected error, got nil")
+	}
+	if err := ValidateFieldPath(longPath); err != nil {
+		t.Errorf("ValidateFieldPath must accept legacy over-cap paths, got: %v", err)
+	}
+
+	// New* still enforce the charset rules on top of the length cap.
+	if err := ValidateNewCatalog("ten:ant"); err == nil {
+		t.Error("ValidateNewCatalog bad charset: expected error, got nil")
+	}
+	if err := ValidateNewFieldPath("no-slash"); err == nil {
+		t.Error("ValidateNewFieldPath bad shape: expected error, got nil")
 	}
 }

--- a/internal/utils/validate_storage_test.go
+++ b/internal/utils/validate_storage_test.go
@@ -1,9 +1,13 @@
 package utils
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidateStorageProviderBucket(t *testing.T) {
-	valid := []string{"oss", "s3", "cos", "mem", "my-bucket", "b.example", "B_2", "0start"}
+	valid := []string{"oss", "s3", "cos", "mem", "my-bucket", "b.example", "B_2", "0start",
+		strings.Repeat("b", MaxStoragePartLen)} // exactly at the length cap
 	for _, s := range valid {
 		if err := ValidateStorageProvider(s); err != nil {
 			t.Errorf("provider %q: unexpected error: %v", s, err)
@@ -15,7 +19,8 @@ func TestValidateStorageProviderBucket(t *testing.T) {
 
 	// "/" and ":" would desynchronise BuildURI/ParseURI; the rest are the
 	// usual delimiter / convention hazards shared with catalog names.
-	invalid := []string{"", "a/b", "a:b", "a|b", ".hidden", "-flag", "空", "a b", "a\tb"}
+	invalid := []string{"", "a/b", "a:b", "a|b", ".hidden", "-flag", "空", "a b", "a\tb",
+		strings.Repeat("b", MaxStoragePartLen+1)}
 	for _, s := range invalid {
 		if err := ValidateStorageProvider(s); err == nil {
 			t.Errorf("provider %q: expected error, got nil", s)

--- a/sample.go
+++ b/sample.go
@@ -82,7 +82,9 @@ func NewSampler[T any](indicator string, loader func(*ListResult) (T, error), op
 	if indicator == "" {
 		panic("lake: NewSampler indicator must be non-empty")
 	}
-	if err := utils.ValidateCatalog(indicator); err != nil {
+	// ValidateNewCatalog: an indicator mints new memo-hash state, so the
+	// length cap applies (it is code-chosen, so failing fast is cheap).
+	if err := utils.ValidateNewCatalog(indicator); err != nil {
 		panic(fmt.Sprintf("lake: NewSampler invalid indicator: %v", err))
 	}
 	if loader == nil {

--- a/sample.go
+++ b/sample.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hkloudou/lake/v3/internal/index"
 	"github.com/hkloudou/lake/v3/internal/utils"
 	"github.com/redis/go-redis/v9"
 )
@@ -386,7 +387,7 @@ func (c *Client) InvalidateSamples(ctx context.Context, indicator string, catalo
 	for i, cat := range catalogs {
 		args[i] = cat
 	}
-	res, err := luaSampleInvalidate.Run(ctx, c.sampleRdb,
+	res, err := index.RunScript(ctx, c.sampleRdb, luaSampleInvalidate,
 		[]string{c.reader.MakeSampleIndicatorKey(indicator)}, args...).Result()
 	if err != nil {
 		return 0, err
@@ -506,7 +507,7 @@ func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResu
 			// value the current log may no longer support), keep the result.
 			return string(data), nil
 		}
-		if werr := luaSampleWrite.Run(ctx, c.sampleRdb,
+		if werr := index.RunScript(ctx, c.sampleRdb, luaSampleWrite,
 			[]string{hashKey, c.reader.MakeSampleRemoveGenKey()},
 			epoch, catGen, list.catalog, data).Err(); werr != nil {
 			c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hset", "err": werr.Error()})

--- a/sample.go
+++ b/sample.go
@@ -351,8 +351,8 @@ return n
 // luaSampleWrite / luaSampleInvalidate dispatch the two sample scripts by SHA
 // (EVALSHA with EVAL fallback on a cold script cache).
 var (
-	luaSampleWrite      = redis.NewScript(sampleWriteScript)
-	luaSampleInvalidate = redis.NewScript(sampleInvalidateScript)
+	luaSampleWrite      = index.NewScript(sampleWriteScript)
+	luaSampleInvalidate = index.NewScript(sampleInvalidateScript)
 )
 
 // InvalidateSamples deletes the cached samples of one indicator for the given

--- a/sample.go
+++ b/sample.go
@@ -345,6 +345,13 @@ end
 return n
 `
 
+// luaSampleWrite / luaSampleInvalidate dispatch the two sample scripts by SHA
+// (EVALSHA with EVAL fallback on a cold script cache).
+var (
+	luaSampleWrite      = redis.NewScript(sampleWriteScript)
+	luaSampleInvalidate = redis.NewScript(sampleInvalidateScript)
+)
+
 // InvalidateSamples deletes the cached samples of one indicator for the given
 // catalogs and returns how many entries existed. The next Sample/Batch
 // recomputes them. Deletion and the epoch bump are atomic, so a compute
@@ -377,7 +384,7 @@ func (c *Client) InvalidateSamples(ctx context.Context, indicator string, catalo
 	for i, cat := range catalogs {
 		args[i] = cat
 	}
-	res, err := c.sampleRdb.Eval(ctx, sampleInvalidateScript,
+	res, err := luaSampleInvalidate.Run(ctx, c.sampleRdb,
 		[]string{c.reader.MakeSampleIndicatorKey(indicator)}, args...).Result()
 	if err != nil {
 		return 0, err
@@ -497,7 +504,7 @@ func (s *Sampler[T]) loadAndCache(ctx context.Context, c *Client, list *ListResu
 			// value the current log may no longer support), keep the result.
 			return string(data), nil
 		}
-		if werr := c.sampleRdb.Eval(ctx, sampleWriteScript,
+		if werr := luaSampleWrite.Run(ctx, c.sampleRdb,
 			[]string{hashKey, c.reader.MakeSampleRemoveGenKey()},
 			epoch, catGen, list.catalog, data).Err(); werr != nil {
 			c.emitEvent(list.catalog, "SampleCacheError", map[string]any{"op": "hset", "err": werr.Error()})

--- a/write.go
+++ b/write.go
@@ -86,10 +86,12 @@ func (c *Client) WriteBegin(ctx context.Context, req WriteBeginRequest, opts ...
 		"path": req.Path, "mergeType": int(req.MergeType), "provider": req.Provider, "bucket": req.Bucket,
 	})
 
-	if err := utils.ValidateCatalog(req.Catalog); err != nil {
+	// New* variants: WriteBegin mints new index/storage state, so the length
+	// caps apply here (read/ops paths accept longer legacy names).
+	if err := utils.ValidateNewCatalog(req.Catalog); err != nil {
 		return nil, err
 	}
-	if err := utils.ValidateFieldPath(req.Path); err != nil {
+	if err := utils.ValidateNewFieldPath(req.Path); err != nil {
 		return nil, err
 	}
 	if req.MergeType < MergeTypeReplace || req.MergeType > MergeTypeRFC7396 {
@@ -199,10 +201,12 @@ func (c *Client) WriteNotify(ctx context.Context, h *WriteHandle) error {
 	}
 	c.emitEvent(h.Catalog, "WriteNotify", map[string]any{"path": h.Path, "uri": h.URI})
 
-	if err := utils.ValidateCatalog(h.Catalog); err != nil {
+	// New* variants: the handle is untrusted input about to be recorded, so
+	// it is held to the same length caps WriteBegin enforces.
+	if err := utils.ValidateNewCatalog(h.Catalog); err != nil {
 		return err
 	}
-	if err := utils.ValidateFieldPath(h.Path); err != nil {
+	if err := utils.ValidateNewFieldPath(h.Path); err != nil {
 		return err
 	}
 	if h.MergeType < MergeTypeReplace || h.MergeType > MergeTypeRFC7396 {


### PR DESCRIPTION
Three KISS-aligned improvements — no new concepts, no behavior changes for valid input — refined across five Codex review rounds (all 10 threads addressed and resolved).

## 1. `perf:` dispatch all Lua by EVALSHA, not full-body EVAL

Every `List` / `WriteNotify` / `AddSnap` / `Compact` / `RemoveDelta` / sample script call was re-sending its script body (~1 KB) to Redis — and `BatchList`'s pipeline sent one copy **per catalog** per round-trip. All seven scripts now route through one `index.RunScript` helper (plus BatchList's pipelined mirror), hardened by review:

- **EVALSHA with full-body EVAL fallback** on: a cold script cache (`NOSCRIPT`, including the `ERR NOSCRIPT` spelling some compatible servers use — go-redis's own `Script.Run` only matches real Redis's exact message), and an ACL that denies the `EVALSHA` command itself (`NOPERM … 'evalsha'`). Only the `EVAL` permission is strictly required — no `SCRIPT LOAD`.
- **A NOPERM raised *inside* a script never retries** — earlier script writes are not rolled back, so a rerun could double-apply them.
- **`fips140=only` safe**: script values compile lazily behind a recover; when local SHA-1 is unavailable, dispatch permanently degrades to plain `EVAL` (the pre-PR behavior) instead of panicking at import (reproduced on go1.25.11).
- The 5s reader clock drops its one-line Lua for the native `TIME` command.

Pinned by `TestScriptDispatchSurvivesScriptFlush` (real `SCRIPT FLUSH`; opt-in via `LAKE_TEST_SCRIPT_FLUSH=1`, enabled in CI — it clears the server-wide script cache, so it must not run against a shared Redis by default), fake-Scripter tests for every fallback/no-retry spelling, and a degrade test for the FIPS path.

## 2. `fix:` bound identifier lengths — at creation time only

Catalog/indicator, field path, and provider/bucket lengths were unbounded: a pathological name passed validation and failed far away with a confusing storage-level error, or quietly bloated the index. Caps now bind **only where a name mints new state** (`WriteBegin` / `WriteNotify` / `NewSampler` / `WithSnapTarget`); reads, member decoding, and ops paths (`List`, `RemoveDelta`, `Compact`, `InvalidateSamples`) keep accepting longer pre-existing names — tightening a cap can never strand persisted data.

| Identifier | Cap (new writes) | Binding constraint |
|---|---|---|
| catalog / indicator | 128 bytes | base32(128) = 208 chars, under the 255-byte path-component limit |
| field path | 512 bytes | recorded verbatim in every delta member |
| provider / bucket | 128 bytes | Lake's own backend-agnostic sanity bound; real stores (OSS/S3: 63) surface their tighter rules themselves |

README synced; boundary tests plus legacy-acceptance tests (over-cap names still list/decode).

## 3. `test:` configurable integration-test Redis

`LAKE_TEST_REDIS_ADDR=host:port` points the Redis-backed tests anywhere (devcontainers, compose hosts); default stays `127.0.0.1:6379`. Both helpers (root package and `internal/index`) honour it.

## Verification

- `gofmt` clean, `go vet ./...` clean
- `go test -count=1 ./...` and `-race` — all 9 packages pass against a live Redis 7, `LAKE_TEST_SCRIPT_FLUSH=1` exercised
- `GODEBUG=fips140=only` run of the index tests: import survives, dispatch degrades to plain `EVAL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWwQ4oM7RZGoU1Y9BmAQrZ