### PR TITLE
V3: contain user-code panics, stop no-op state minting, harden OSS config

### DIFF
--- a/internal/index/reader.go
+++ b/internal/index/reader.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"sync"
@@ -189,6 +190,31 @@ func parseListReply(res any) (string, string, []redis.Z, error) {
 	return rawSnap, removeGen, zs, nil
 }
 
+// HasDelta reports whether a delta with the given tsSeq currently exists in
+// the catalog's zset — the same score-range + embedded-tsSeq match the
+// removal script performs, read-only. RemoveDelta probes with it before
+// installing barriers, so a mistyped catalog or tsSeq mints no state.
+func (r *Reader) HasDelta(ctx context.Context, catalog string, tsSeq TimeSeqID) (bool, error) {
+	score := strconv.FormatFloat(tsSeq.Score(), 'f', -1, 64)
+	members, err := r.rdb.ZRangeByScore(ctx, r.MakeDeltaZsetKey(catalog),
+		&redis.ZRangeBy{Min: score, Max: score}).Result()
+	if err != nil {
+		return false, err
+	}
+	want := tsSeq.String()
+	for _, m := range members {
+		var arr []json.RawMessage
+		if json.Unmarshal([]byte(m), &arr) != nil || len(arr) != 4 {
+			continue
+		}
+		var got string
+		if json.Unmarshal(arr[2], &got) == nil && got == want {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // RemoveGen returns the catalog's current removal generation ("0" if no
 // delta was ever removed). Sample write-backs recheck it against the
 // generation captured with their ListResult: a loader computing from a list
@@ -276,14 +302,22 @@ func (r *Reader) BatchList(ctx context.Context, catalogs []string) map[string]*B
 	cmds := r.evalListPipelined(ctx, catalogs, false)
 	// RunScript's fallback cannot fire inside a pipeline (command errors
 	// surface only at Exec), so it is mirrored here with the same predicate:
-	// re-run the whole pipeline with full-body EVAL, which executes AND
-	// re-caches the script in one step — no SCRIPT LOAD (or even EVALSHA)
-	// permission required. Rare — a cold script cache, or an ACL that denies
-	// EVALSHA; listScript is read-only, so re-running is always safe.
-	for _, cmd := range cmds {
-		if needsEvalFallback(cmd.Err()) {
-			cmds = r.evalListPipelined(ctx, catalogs, true)
-			break
+	// re-run with full-body EVAL, which executes AND re-caches the script in
+	// one step — no SCRIPT LOAD (or even EVALSHA) permission required. Rare —
+	// a cold script cache, or an ACL that denies EVALSHA; listScript is
+	// read-only, so re-running is always safe. Only the catalogs that
+	// actually failed are retried: first-pass successes keep their results
+	// (a transient blip in the retry must not erase them), and the retry
+	// pipeline stays proportional to the failure, not the fleet.
+	var retry []string
+	for _, cat := range catalogs {
+		if needsEvalFallback(cmds[cat].Err()) {
+			retry = append(retry, cat)
+		}
+	}
+	if len(retry) > 0 {
+		for cat, cmd := range r.evalListPipelined(ctx, retry, true) {
+			cmds[cat] = cmd
 		}
 	}
 

--- a/longtail_integration_test.go
+++ b/longtail_integration_test.go
@@ -110,6 +110,37 @@ func TestNotifyMonotonicAcrossClockRegression_Redis(t *testing.T) {
 	}
 }
 
+// TestRemoveDeltaNoStateForMissingTarget_Redis: RemoveDelta on a nonexistent
+// catalog/tsSeq must be a pure no-op — the pre-removal barrier bump must not
+// mint a permanent "<prefix>:mrg" field for a name that holds nothing (a
+// mistyped ops call, or an arbitrarily long legacy-format name this path
+// accepts, must not grow Redis state per attempt).
+func TestRemoveDeltaNoStateForMissingTarget_Redis(t *testing.T) {
+	c, store, ctx := newMemClient(t)
+
+	if removed, err := c.RemoveDelta(ctx, "no-such-catalog", "1700000000_1"); err != nil || removed {
+		t.Fatalf("RemoveDelta(missing) = %v, %v; want false, nil", removed, err)
+	}
+	if n, err := c.sampleRdb.HExists(ctx, c.reader.MakeSampleRemoveGenKey(), "no-such-catalog").Result(); err != nil || n {
+		t.Fatalf("mrg field minted for a nonexistent catalog (exists=%v err=%v)", n, err)
+	}
+
+	// A real catalog with the WRONG tsSeq must also stay state-free.
+	writeDelta(t, c, store, "users", "/", MergeTypeReplace, `{"a":1}`)
+	if removed, err := c.RemoveDelta(ctx, "users", "1600000000_1"); err != nil || removed {
+		t.Fatalf("RemoveDelta(wrong tsSeq) = %v, %v; want false, nil", removed, err)
+	}
+	if n, _ := c.sampleRdb.HExists(ctx, c.reader.MakeSampleRemoveGenKey(), "users").Result(); n {
+		t.Fatal("mrg field minted for a wrong-tsSeq removal attempt")
+	}
+
+	// And the real removal still works end to end.
+	list := c.List(ctx, "users")
+	if removed, err := c.RemoveDelta(ctx, "users", list.Entries[0].TsSeq.String()); err != nil || !removed {
+		t.Fatalf("real RemoveDelta = %v, %v; want true, nil", removed, err)
+	}
+}
+
 // TestSampleEmptyCatalogCachesOnce: the sample of a still-empty catalog is a
 // legitimate cacheable value — the loader must run once, not on every call.
 func TestSampleEmptyCatalogCachesOnce_Redis(t *testing.T) {

--- a/read.go
+++ b/read.go
@@ -17,10 +17,20 @@ import (
 // and the per-catalog save slot forever.
 const snapSaveTimeout = 5 * time.Minute
 
+// panicToErr converts a panic on a Lake-owned goroutine into an error via
+// the deferred pattern `defer panicToErr(&err)`. It deliberately does NOT
+// run on normal returns (recover() is nil then).
+func panicToErr(dst *error) {
+	if r := recover(); r != nil {
+		*dst = fmt.Errorf("lake: user-provided code panicked: %v", r)
+	}
+}
+
 // readData loads the snapshot bytes and delta bodies in parallel, merges them
 // into the resulting document, and (when a snap target is configured)
 // asynchronously persists a new snapshot if there are deltas past the snap.
 func (c *Client) readData(ctx context.Context, list *ListResult) ([]byte, error) {
+	c.emitEvent(list.catalog, "Read", nil)
 	if list.Err != nil {
 		return nil, list.Err
 	}
@@ -38,7 +48,12 @@ func (c *Client) readData(ctx context.Context, list *ListResult) ([]byte, error)
 		baseDataErr, deltaErr error
 		wg                    sync.WaitGroup
 	)
+	// Both goroutines run user-provided code (storage backends via the
+	// Resolver). They are Lake-owned goroutines with no caller stack to
+	// recover on, so a backend panic here would kill the whole process —
+	// contain it as a read error instead (same policy as saveSnapshotGuarded).
 	wg.Go(func() {
+		defer panicToErr(&baseDataErr)
 		if list.LatestSnap == nil {
 			baseData = []byte("{}")
 			return
@@ -46,6 +61,7 @@ func (c *Client) readData(ctx context.Context, list *ListResult) ([]byte, error)
 		baseData, baseDataErr = c.fetchURI(ctx, storage.Snap, list.catalog, list.LatestSnap.URI)
 	})
 	wg.Go(func() {
+		defer panicToErr(&deltaErr)
 		deltaErr = c.fillDeltasBody(ctx, list.catalog, entries)
 	})
 	wg.Wait()
@@ -176,6 +192,19 @@ func (c *Client) fillDeltasBody(ctx context.Context, catalog string, deltas []in
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		wg.Go(func() {
+			// Pool workers call user storage backends; a panic in one must
+			// surface as this read's error, not kill the process.
+			var panicErr error
+			defer func() {
+				if panicErr != nil {
+					select {
+					case errCh <- panicErr:
+					default:
+					}
+					cancel()
+				}
+			}()
+			defer panicToErr(&panicErr)
 			for d := range jobs {
 				if err := workerCtx.Err(); err != nil {
 					return

--- a/remove.go
+++ b/remove.go
@@ -52,6 +52,19 @@ func (c *Client) RemoveDelta(ctx context.Context, catalog, tsSeq string) (bool, 
 	if err != nil {
 		return false, err
 	}
+	// Probe existence BEFORE installing any barrier: the bumps below mint
+	// permanent hash fields keyed by the caller-supplied catalog, and an
+	// operator retrying with a mistyped (or arbitrarily long — this path
+	// accepts legacy names the write-side caps reject) catalog/tsSeq must
+	// not grow Redis state on every attempt. The probe-then-remove gap is
+	// benign: tsSeq allocation is monotonic, so a delta can only DISAPPEAR
+	// between the two (removed=false with a harmless extra bump), never
+	// appear.
+	if exists, err := c.reader.HasDelta(ctx, catalog, id); err != nil {
+		return false, fmt.Errorf("probe delta: %w", err)
+	} else if !exists {
+		return false, nil
+	}
 	// Install the sample write barrier BEFORE removing anything: if the bump
 	// failed after the ZREM (e.g. a separate sample-cache Redis briefly
 	// down), the delta would be gone with the barrier at the old generation,

--- a/sample.go
+++ b/sample.go
@@ -297,7 +297,20 @@ func (s *Sampler[T]) Batch(ctx context.Context, lists map[string]*ListResult) ma
 				// Re-read the clock per loader run: with many misses ahead in
 				// the queue, the batch-start `now` could stamp an UpdatedAt
 				// already a whole maxAge in the past.
-				v, e := s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), c.reader.NowUnix(), epoch, catGen(cat)))
+				//
+				// The loader is user code running on a Lake-owned worker
+				// goroutine — a panic here has no caller stack to recover on
+				// and would kill the process (unlike Sample, where it
+				// surfaces in the caller). Contain it as this catalog's
+				// error.
+				v, e := func() (v T, e error) {
+					defer func() {
+						if r := recover(); r != nil {
+							e = fmt.Errorf("lake: sampler loader panicked: %v", r)
+						}
+					}()
+					return s.finalize(s.loadAndCache(ctx, c, l, hashKey, l.LastUpdated(), c.reader.NowUnix(), epoch, catGen(cat)))
+				}()
 				mu.Lock()
 				out[cat] = &SampleResult[T]{Value: v, Err: e}
 				mu.Unlock()
@@ -377,7 +390,12 @@ func (c *Client) InvalidateSamples(ctx context.Context, indicator string, catalo
 	for _, cat := range catalogs {
 		c.emitEvent(cat, "InvalidateSample", map[string]any{"indicator": indicator})
 	}
-	if err := utils.ValidateCatalog(indicator); err != nil {
+	// ValidateNewCatalog, not the read-side form: the epoch bump below
+	// CREATES the memo hash when it does not exist (that is what lets it
+	// barrier an indicator that has never cached anything), so an oversized
+	// indicator here would mint a permanent Redis key. Indicators are
+	// code-chosen and NewSampler enforces the same cap.
+	if err := utils.ValidateNewCatalog(indicator); err != nil {
 		return 0, fmt.Errorf("invalid indicator: %w", err)
 	}
 	for _, cat := range catalogs {

--- a/storage/cached/cached.go
+++ b/storage/cached/cached.go
@@ -60,9 +60,14 @@ func Wrap(namespace string, base storage.Storage, cache Cache) storage.Storage {
 
 // Resolver wraps every Storage that inner returns with the cache chosen by
 // policy(kind, provider, bucket); a nil policy result leaves that backend
-// uncached. Keys are namespaced by "provider|bucket". Because Lake passes the
-// object Kind, one bucket can cache snapshots and skip deltas with no path
-// inspection and no bucket split:
+// uncached. Keys are namespaced by "provider|bucket" — NOT by deployment:
+// two Lake deployments sharing one cache Redis whose resolvers map the same
+// (provider, bucket) pair to DIFFERENT physical buckets (e.g. staging and
+// prod both calling it "oss"/"data" against separate accounts) would collide
+// on cache keys and could serve each other's bytes. Give such deployments
+// separate cache instances/DBs, or distinct provider/bucket naming. Because
+// Lake passes the object Kind, one bucket can cache snapshots and skip
+// deltas with no path inspection and no bucket split:
 //
 //	resolve := cached.Resolver(backends, func(kind storage.Kind, provider, bucket string) cached.Cache {
 //	    if kind == storage.Snap {

--- a/storage/oss/oss.go
+++ b/storage/oss/oss.go
@@ -38,16 +38,36 @@ type Client struct {
 }
 
 // New builds an OSS client. It returns an error only on malformed config; the
-// connection is lazy. Resolve the endpoint shorthand the same way the v3
-// config layer used to.
+// connection is lazy.
+//
+// Endpoint forms: a region shorthand ("oss-cn-hangzhou" — Internal and
+// FC_REGION handling apply, ".aliyuncs.com" is appended), a full host
+// ("oss-cn-hangzhou-internal.aliyuncs.com"), or a full URL. Internal=true is
+// only meaningful with the shorthand — combined with a host/URL it would
+// have to rewrite an address the caller already spelled out, so that
+// combination is rejected loudly instead of minting a host that fails DNS
+// on the first request.
 func New(cfg Config) (*Client, error) {
 	endpoint := cfg.Endpoint
-	if cfg.Internal {
-		endpoint += "-internal"
-	}
-	if !strings.HasPrefix(endpoint, "http") {
-		if r := os.Getenv("FC_REGION"); r != "" && strings.Contains(endpoint, r) && !strings.Contains(endpoint, "-internal") {
-			endpoint += "-internal"
+	switch {
+	case strings.HasPrefix(endpoint, "http://"), strings.HasPrefix(endpoint, "https://"):
+		if cfg.Internal && !strings.Contains(endpoint, "-internal") {
+			return nil, fmt.Errorf("oss: Internal requires the region-shorthand Endpoint (e.g. %q); bake \"-internal\" into the full URL %q instead", "oss-cn-hangzhou", cfg.Endpoint)
+		}
+	case strings.Contains(endpoint, "."):
+		// Full host without a scheme — never re-suffix ".aliyuncs.com".
+		if cfg.Internal && !strings.Contains(endpoint, "-internal") {
+			return nil, fmt.Errorf("oss: Internal requires the region-shorthand Endpoint (e.g. %q); bake \"-internal\" into the host %q instead", "oss-cn-hangzhou", cfg.Endpoint)
+		}
+		endpoint = "https://" + endpoint
+	default:
+		// Region shorthand.
+		if !strings.Contains(endpoint, "-internal") {
+			if cfg.Internal {
+				endpoint += "-internal"
+			} else if r := os.Getenv("FC_REGION"); r != "" && strings.Contains(endpoint, r) {
+				endpoint += "-internal"
+			}
 		}
 		endpoint = "https://" + endpoint + ".aliyuncs.com"
 	}
@@ -114,6 +134,12 @@ func (b *bucket) PresignPut(_ context.Context, _ /*catalog*/, path string, opts 
 	if ttl <= 0 {
 		ttl = 15 * time.Minute
 	}
+	// SignURL takes whole seconds; a sub-second TTL would truncate to 0 and
+	// sign a URL that is already expired when returned.
+	expireSecs := int64(ttl / time.Second)
+	if expireSecs < 1 {
+		expireSecs = 1
+	}
 	signOpts := []alioss.Option{}
 	headers := map[string]string{}
 	if opts.ContentType != "" {
@@ -124,7 +150,7 @@ func (b *bucket) PresignPut(_ context.Context, _ /*catalog*/, path string, opts 
 		signOpts = append(signOpts, alioss.Meta(k, v))
 		headers["x-oss-meta-"+strings.ToLower(k)] = v
 	}
-	url, err := h.SignURL(path, alioss.HTTPPut, int64(ttl.Seconds()), signOpts...)
+	url, err := h.SignURL(path, alioss.HTTPPut, expireSecs, signOpts...)
 	if err != nil {
 		return storage.PresignedUpload{}, fmt.Errorf("oss: sign url: %w", err)
 	}

--- a/write.go
+++ b/write.go
@@ -127,6 +127,11 @@ func (c *Client) WriteBegin(ctx context.Context, req WriteBeginRequest, opts ...
 	}
 	if o.ttl <= 0 {
 		o.ttl = defaultUploadTTL
+	} else if o.ttl < time.Second {
+		// Presign APIs take whole seconds and ExpiresAt is unix seconds; a
+		// sub-second TTL (e.g. an untyped WithUploadTTL(30) — 30ns) would
+		// otherwise round to an already-expired handle.
+		o.ttl = time.Second
 	}
 
 	uuid, err := newUUID()
@@ -261,7 +266,10 @@ func (c *Client) WriteNotify(ctx context.Context, h *WriteHandle) error {
 		// secret the field is client-editable, so checking it there would
 		// only be theater.) Compared against the Redis-synced clock — the
 		// same one WriteBegin stamped from — so cross-host clock skew cannot
-		// shift the effective TTL.
+		// shift the effective TTL. EnsureClock mirrors WriteBegin's: a
+		// notify-only host must not judge expiry on its local clock during
+		// its own pre-first-sync window.
+		c.reader.EnsureClock(ctx)
 		if now := c.reader.NowUnix(); now > h.ExpiresAt {
 			return fmt.Errorf("handle expired at %d (now %d)", h.ExpiresAt, now)
 		}


### PR DESCRIPTION
## Summary

Third audit round over V3, focused on (a) the merge seam between the two prior workstreams (#18, #19) and (b) previously unaudited corners (`storage/oss`, resolver composition, event contract). One commit.

### Process-kill class: user-code panics on Lake-owned goroutines

Sampler loaders in `Batch`'s worker pool, and storage backends in `readData`'s two fetch goroutines and `fillDeltasBody`'s pool, ran on Lake-owned goroutines with **no caller stack to recover on** — one panicking loader or backend killed the whole process, while the very same code panicking via `Sample` or a direct call surfaces in the caller, and `saveSnapshotGuarded` already contained the snapshot path. Panics there now surface as ordinary per-call / per-catalog errors (`lake: user-provided code panicked: ...`).

### No-op calls must not mint permanent Redis state

- `RemoveDelta` installed its pre-removal barrier (`HINCRBY <prefix>:mrg <catalog>`) **before** checking the target exists — a mistyped or oversized catalog name (this path deliberately accepts legacy names the write-side caps reject) grew a permanent hash field on every retry. A read-only existence probe (`Reader.HasDelta`) now precedes the barriers; probe-then-remove is race-safe because tsSeq allocation is monotonic — a delta can only *disappear* between the two, never appear. Pinned by `TestRemoveDeltaNoStateForMissingTarget_Redis`.
- `InvalidateSamples` gets the write-side length cap on the indicator: its epoch bump *creates* the memo hash (that is what lets it barrier a never-cached indicator), so an oversized name would mint a permanent key.

### Clock symmetry

`WriteNotify` now mirrors `WriteBegin`'s `EnsureClock` before the signed-handle expiry check — a notify-only host must not judge expiry on its local clock during its own pre-first-sync window.

### BatchList cold-cache retry keeps first-pass successes

The EVAL fallback re-ran the **entire** pipeline when any one catalog hit NOSCRIPT — discarding results that had already succeeded (a transient blip in the retry could turn a pass-1 success into an error) and shipping the full script body for the whole fleet. Only the failed subset is retried now.

### OSS backend hardening

- `Internal: true` combined with a full URL or dotted host appended `-internal` to the **end of the whole string** (`https://oss-cn-hangzhou.aliyuncs.com-internal`) — unresolvable, and only discovered on the first request since the connection is lazy. Rejected loudly at `New` with guidance; dotted hosts also no longer get `.aliyuncs.com` re-appended.
- Sub-second presign TTLs truncated to `expiredInSec=0` — a signed URL already expired when returned (classic trap: an untyped `WithUploadTTL(30)` is 30 *nanoseconds*). Rounded up to 1s at the OSS layer, and `WriteBegin` normalizes sub-second TTLs so `ExpiresAt` agrees.

### Observability

`readData` emits a `Read` event, closing the one gap in the "every API call emits an event" contract (document reads — the calls that actually hit object storage — were invisible to metrics/audit handlers). `cached.Resolver` documents the cross-deployment cache-key hazard of sharing one cache Redis between environments that reuse (provider, bucket) names.

### Evaluated, deliberately not changed

- Double `SnapshotError` emit when an event *handler itself* panics during the error emit — the two events describe two distinct failures; not worth the complexity.
- Legacy >158-byte catalogs can still fail file-backend snapshot saves with `ENAMETOOLONG` (pre-cap names, alpha-era only) — recorded as a known limitation.

## Test plan

- `go test -race -count=1 ./...` green against live Redis 7; `gofmt` / `go vet` clean; CI recipe (incl. `LAKE_TEST_SCRIPT_FLUSH=1`) run locally.
- New regression test: `TestRemoveDeltaNoStateForMissingTarget_Redis` (missing catalog, wrong tsSeq, then a real removal end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mmzipWTEKTLL7NMZK9eHX

---
_Generated by [Claude Code](https://claude.ai/code/session_015mmzipWTEKTLL7NMZK9eHX)_